### PR TITLE
Add the History as enabled by default

### DIFF
--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -430,10 +430,7 @@ FORGE.Viewer.prototype._parseMainConfig = function(config)
         this._i18n.addConfig(config.i18n); //force the parse of the main config
     }
 
-    if (typeof config.history !== "undefined")
-    {
-        this._history.addConfig(config.history);
-    }
+    this._history.addConfig(config.history);
 
     if (typeof config.audio !== "undefined")
     {

--- a/src/system/History.js
+++ b/src/system/History.js
@@ -16,26 +16,29 @@ FORGE.History = function(viewer)
     this._viewer = viewer;
 
     /**
-     * History configuration
-     * @name FORGE.History#_config
-     * @type {HistoryConfig}
-     * @private
-     */
-    this._config;
-
-    /**
      * The history module enabled flag.
      * @name  FORGE.History#_enabled
      * @type {boolean}
      * @private
      */
-    this._enabled = true;
+    this._enabled = false;
 
     FORGE.BaseObject.call(this, "History");
 };
 
 FORGE.History.prototype = Object.create(FORGE.BaseObject.prototype);
 FORGE.History.prototype.constructor = FORGE.History;
+
+/**
+ * Default configuration of the History
+ * @name FORGE.History.DEFAULT_CONFIG
+ * @type {HistoryConfig}
+ * @const
+ */
+FORGE.History.DEFAULT_CONFIG =
+{
+    enabled: true
+};
 
 /**
  * Boot sequence.
@@ -45,7 +48,7 @@ FORGE.History.prototype.constructor = FORGE.History;
  */
 FORGE.History.prototype._parseConfig = function(config)
 {
-    this._config = config;
+    config = /** @type {HistoryConfig} */ (FORGE.Utils.extendSimpleObject(FORGE.History.DEFAULT_CONFIG, config));
 
     this._enabled = (typeof config.enabled === "boolean") ? config.enabled : true;
 

--- a/src/system/History.js
+++ b/src/system/History.js
@@ -16,6 +16,14 @@ FORGE.History = function(viewer)
     this._viewer = viewer;
 
     /**
+     * History configuration
+     * @name FORGE.History#_config
+     * @type {HistoryConfig}
+     * @private
+     */
+    this._config;
+
+    /**
      * The history module enabled flag.
      * @name  FORGE.History#_enabled
      * @type {boolean}
@@ -48,9 +56,9 @@ FORGE.History.DEFAULT_CONFIG =
  */
 FORGE.History.prototype._parseConfig = function(config)
 {
-    config = /** @type {HistoryConfig} */ (FORGE.Utils.extendSimpleObject(FORGE.History.DEFAULT_CONFIG, config));
+    this._config = /** @type {HistoryConfig} */ (FORGE.Utils.extendSimpleObject(FORGE.History.DEFAULT_CONFIG, config));
 
-    this._enabled = (typeof config.enabled === "boolean") ? config.enabled : true;
+    this._enabled = (typeof this._config.enabled === "boolean") ? this._config.enabled : true;
 
     if (this._enabled === true)
     {


### PR DESCRIPTION
It was the case before, but it wasn't going through the `_enable` function which adds event listeners.