### PR TITLE
Render without background feature

### DIFF
--- a/externs/lib/three.ext.js
+++ b/externs/lib/three.ext.js
@@ -216,9 +216,9 @@ THREE.TextureLoader = function() {};
 
 /**
  * @param  {string} arg1
- * @param  {function(THREE.Texture): undefined} arg2
- * @param  {function(XMLHttpRequest): undefined} arg3
- * @param  {function(XMLHttpRequest): undefined} arg4
+ * @param  {function(THREE.Texture): undefined=} arg2
+ * @param  {function(XMLHttpRequest): undefined=} arg3
+ * @param  {function(XMLHttpRequest): undefined=} arg4
  */
 THREE.TextureLoader.prototype.load = function(arg1, arg2, arg3, arg4) {};
 
@@ -856,6 +856,9 @@ THREE.Material = function() {};
 
 /** @type {THREE.WebGLProgram} */
 THREE.Material.prototype.program;
+
+/** @type {Object} */
+THREE.Material.prototype.extensions;
 
 /**
  */

--- a/src/render/RenderManager.js
+++ b/src/render/RenderManager.js
@@ -548,7 +548,7 @@ FORGE.RenderManager.prototype._setupRenderPipeline = function()
         fxSet = this._viewer.postProcessing.getFxSetByUID(this._sceneConfig.media.fx);
     }
 
-    this._renderPipeline.addBackground(this._backgroundRenderer.renderTarget.texture, fxSet);
+    this._renderPipeline.addBackground(this._backgroundRenderer.renderTarget.texture, fxSet, 1.0);
 
     if (typeof this._sceneConfig.fx !== "undefined" && this._sceneConfig.fx !== null)
     {
@@ -567,10 +567,12 @@ FORGE.RenderManager.prototype._drawBackground = function(camera)
 {
     // this.log("_drawBackground");
 
-    if (this._backgroundRenderer !== null)
+    if (this._backgroundRenderer === null)
     {
-        this._backgroundRenderer.render(camera || null);
+        return;
     }
+
+    this._backgroundRenderer.render(camera || null);
 };
 
 /**
@@ -775,53 +777,51 @@ FORGE.RenderManager.prototype.update = function()
  */
 FORGE.RenderManager.prototype.render = function()
 {
-    if (this._backgroundReady === false ||
-        this._viewReady === false ||
+    if (this._viewReady === false ||
         this._renderPipeline === null)
     {
         return;
     }
 
-    this._backgroundRenderer.update();
-
-    // Render
-    if (this._backgroundReady === true)
+    if (this._backgroundRenderer !== null)
     {
-        var vr = this._renderDisplay.presentingVR;
-        var renderParams = this._renderDisplay.getRenderParams();
+        this._backgroundRenderer.update();
+    }
+
+    var vr = this._renderDisplay.presentingVR;
+    var renderParams = this._renderDisplay.getRenderParams();
 
 
-        for (var i = 0, ii = renderParams.length; i < ii; i++)
+    for (var i = 0, ii = renderParams.length; i < ii; i++)
+    {
+        var params = renderParams[i];
+        var rect = params.rectangle;
+        var camera = params.camera;
+
+        this._webGLRenderer.setViewport(rect.origin.x, rect.origin.y, rect.size.width, rect.size.height);
+
+        this._drawBackground(vr ? camera : null);
+
+        this._renderPipeline.render(camera);
+
+        // Render perspective camera children (objects in camera local space)
+        this._webGLRenderer.clearDepth();
+
+        //this._camera.gaze.visible = !this._renderDisplay.presentingVR;
+
+        if (vr === true)
         {
-            var params = renderParams[i];
-            var rect = params.rectangle;
-            var camera = params.camera;
+            var scene = new THREE.Scene();
+            scene.add(camera);
+            //window.scene = scene;
 
-            this._webGLRenderer.setViewport(rect.origin.x, rect.origin.y, rect.size.width, rect.size.height);
-
-            this._drawBackground(vr ? camera : null);
-
-            this._renderPipeline.render(camera);
-
-            // Render perspective camera children (objects in camera local space)
-            this._webGLRenderer.clearDepth();
-
-            //this._camera.gaze.visible = !this._renderDisplay.presentingVR;
-
-            if (vr === true)
-            {
-                var scene = new THREE.Scene();
-                scene.add(camera);
-                //window.scene = scene;
-
-                this._webGLRenderer.render(scene, camera);
-            }
+            this._webGLRenderer.render(scene, camera);
         }
+    }
 
-        if (this._renderDisplay.presentingVR === true)
-        {
-            this._renderDisplay.submitFrame();
-        }
+    if (this._renderDisplay.presentingVR === true)
+    {
+        this._renderDisplay.submitFrame();
     }
 
     // @todo implement event for render stats (fps, objects count...)

--- a/src/render/RenderManager.js
+++ b/src/render/RenderManager.js
@@ -155,6 +155,14 @@ FORGE.RenderManager = function(viewer)
     this._viewReady = false;
 
     /**
+     * Render pipeline renderer ready flag
+     * @name FORGE.RenderManager#_renderPipelineReady
+     * @type boolean
+     * @private
+     */
+    this._renderPipelineReady = false;
+
+    /**
      * Hotspot renderer ready flag
      * @name FORGE.RenderManager#_hotspotsReady
      * @type boolean
@@ -314,6 +322,7 @@ FORGE.RenderManager.prototype._onSceneLoadStart = function()
 FORGE.RenderManager.prototype._onSceneUnloadStart = function()
 {
     this._hotspotsReady = false;
+    this._renderPipelineReady = false;
 
     this._clearBackgroundRenderer();
 
@@ -555,6 +564,8 @@ FORGE.RenderManager.prototype._setupRenderPipeline = function()
         var globalFxSet = this._viewer.postProcessing.getFxSetByUID(this._sceneConfig.fx);
         this._renderPipeline.addGlobalFx(globalFxSet);
     }
+
+    this._renderPipelineReady = true;
 };
 
 /**
@@ -778,6 +789,7 @@ FORGE.RenderManager.prototype.update = function()
 FORGE.RenderManager.prototype.render = function()
 {
     if (this._viewReady === false ||
+        this._renderPipelineReady === false ||
         this._renderPipeline === null)
     {
         return;
@@ -790,7 +802,6 @@ FORGE.RenderManager.prototype.render = function()
 
     var vr = this._renderDisplay.presentingVR;
     var renderParams = this._renderDisplay.getRenderParams();
-
 
     for (var i = 0, ii = renderParams.length; i < ii; i++)
     {

--- a/src/render/background/BackgroundMeshRenderer.js
+++ b/src/render/background/BackgroundMeshRenderer.js
@@ -497,7 +497,6 @@ FORGE.BackgroundMeshRenderer.prototype._updateInternals = function()
 
     if (this._mediaType === FORGE.MediaType.GRID)
     {
-        material.extensions.derivatives = true;
         material.uniforms.tColor.value = new THREE.Color(this._gridColor);
         material.blending = THREE.CustomBlending;
         material.blendEquationAlpha = THREE.AddEquation;

--- a/src/render/background/BackgroundMeshRenderer.js
+++ b/src/render/background/BackgroundMeshRenderer.js
@@ -497,6 +497,7 @@ FORGE.BackgroundMeshRenderer.prototype._updateInternals = function()
 
     if (this._mediaType === FORGE.MediaType.GRID)
     {
+        material.extensions.derivatives = true;
         material.uniforms.tColor.value = new THREE.Color(this._gridColor);
         material.blending = THREE.CustomBlending;
         material.blendEquationAlpha = THREE.AddEquation;

--- a/src/render/shader/ShaderChunk/worldToScreen/wts_frag_addition.glsl
+++ b/src/render/shader/ShaderChunk/worldToScreen/wts_frag_addition.glsl
@@ -12,5 +12,6 @@ varying vec2 vUv;
 void main() {
     vec4 texel = texture2D( tTexture, vUv );
     vec4 texelAdd = texture2D( tAdd, vUv );
-    gl_FragColor = vec4(vec3(texelAdd.a * texelAdd.rgb + (1.0 - texelAdd.a) * texel.rgb), 1.0);
+    float alpha = max(texel.a, texelAdd.a);
+    gl_FragColor = vec4(vec3(texelAdd.a * texelAdd.rgb + (1.0 - texelAdd.a) * texel.rgb), alpha);
 }

--- a/src/render/shader/ShaderChunk/worldToScreen/wts_frag_wireframe.glsl
+++ b/src/render/shader/ShaderChunk/worldToScreen/wts_frag_wireframe.glsl
@@ -4,6 +4,8 @@
  * Compute distance to the edge to find what should be displayed
  */
 
+#extension GL_OES_standard_derivatives : enable 
+
 #include <defines>
 
 // Set thickness to 1.5. Seems like 1.0 adds aliasing to the grid.

--- a/src/render/shader/ShaderChunk/worldToScreen/wts_frag_wireframe.glsl
+++ b/src/render/shader/ShaderChunk/worldToScreen/wts_frag_wireframe.glsl
@@ -4,8 +4,6 @@
  * Compute distance to the edge to find what should be displayed
  */
 
-#extension GL_OES_standard_derivatives : enable
-
 #include <defines>
 
 // Set thickness to 1.5. Seems like 1.0 adds aliasing to the grid.


### PR DESCRIPTION
RenderManager: enable render even without background renderer
RenderPipeline: add default TexturePass when there is no background
BackgroundMeshRenderer: add extension derivatives in material for grid media
Fragment addition shader: use max alpha for correct blending without transparent background
Wireframe shader: cleanup withtout extension addition (done by WebGLProgram)
Update ThreeJS externs