### PR TITLE
Add playslinline attribute for HTMLVideoElement

### DIFF
--- a/src/display/video/VideoHTML5.js
+++ b/src/display/video/VideoHTML5.js
@@ -821,7 +821,8 @@ FORGE.VideoHTML5.prototype._createVideoAt = function(index)
 {
     //Create a video tag and get the quality
     var element = document.createElement("video");
-    element.setAttribute("webkit-playsinline", "webkit-playsinline");
+    element.setAttribute("webkit-playsinline", "true");
+    element.setAttribute("playsinline", "true");
     element.setAttribute("width", this.pixelWidth);
     element.setAttribute("height", this.pixelHeight);
     element.volume = 0;


### PR DESCRIPTION
Previous iOS version was using the webkit-playsinline attribute.
Since iOS 10.X the playsinline attribute must be used instead.