### PR TITLE
Video multi qualities

### DIFF
--- a/reference/scene/scene-media-level.json
+++ b/reference/scene/scene-media-level.json
@@ -20,6 +20,17 @@
             "example": "multi/video-2K.mp4"
         },
 
+        "device": {
+            "type": "object",
+            "title": "Device",
+            "description": "The device requirements.",
+            "example": {
+                "safari": false,
+                "webvr": true,
+                "os": "Windows"
+            }
+        },
+
         "width": {
             "type": "number",
             "title": "Width",

--- a/reference/scene/scene-media-options.json
+++ b/reference/scene/scene-media-options.json
@@ -23,10 +23,17 @@
         "volume": {
             "type": "number",
             "title": "Volume",
-            "description": "The volume of the media",
+            "description": "The volume of the media.",
             "minimum": 0,
             "maximum": 1,
             "default": 1
+        },
+
+        "startTime": {
+            "type": "number",
+            "title": "Start Time",
+            "description": "Set the current position (in seconds) of the video playback.",
+            "default": 0
         }
     }
 }

--- a/src/display/video/VideoDash.js
+++ b/src/display/video/VideoDash.js
@@ -2768,7 +2768,7 @@ Object.defineProperty(FORGE.VideoDash.prototype, "onTimeUpdate",
  */
 Object.defineProperty(FORGE.VideoDash.prototype, "onCurrentTimeChange",
 {
-    /** @this {FORGE.VideoHTML5} */
+    /** @this {FORGE.VideoDash} */
     get: function()
     {
         if (this._onCurrentTimeChange === null)

--- a/src/display/video/VideoDash.js
+++ b/src/display/video/VideoDash.js
@@ -1301,9 +1301,9 @@ FORGE.VideoDash.prototype._onDurationChangeHandler = function(event)
     var element = this._video.element;
     this.log("onDurationChange [readyState: " + element.readyState + "]");
 
-    //@firefox - FF disptach durationchange twice on readystate 1 & 4
-    //I will not dispatch this event if readystate is 4 !
-    if (this._onDurationChange !== null && element.readyState === 1)
+    //@firefox - FF disptach durationchange twice on readystate HAVE_METADATA (1) & HAVE_ENOUGH_DATA (4)
+    //I will not dispatch this event if readystate is HAVE_ENOUGH_DATA (4) !
+    if (this._onDurationChange !== null && element.readyState === HTMLMediaElement.HAVE_METADATA)
     {
         this._onDurationChange.dispatch(event);
     }
@@ -1464,9 +1464,9 @@ FORGE.VideoDash.prototype._onVolumeChangeHandler = function(event)
     var element = this._video.element;
     this.log("onVolumeChange [readyState: " + element.readyState + "]");
 
-    //I do not dispatch the volume change if readyState is 0.
+    //I do not dispatch the volume change if readyState is HAVE_NOTHING (0).
     //because I set the volume at 0 when I create the video element, it is not usefull to dispatch this internal volume change ?
-    if (this._onVolumeChange !== null && element.readyState !== 0)
+    if (this._onVolumeChange !== null && element.readyState !== HTMLMediaElement.HAVE_NOTHING)
     {
         this._onVolumeChange.dispatch(event);
     }

--- a/src/display/video/VideoHTML5.js
+++ b/src/display/video/VideoHTML5.js
@@ -1722,9 +1722,9 @@ FORGE.VideoHTML5.prototype._onEventHandler = function(event)
             break;
 
         case "durationchange":
-            //@firefox - FF disptach durationchange twice on readystate 1 & 4
+            //@firefox - FF disptach durationchange twice on readystate HAVE_METADATA (1) & HAVE_ENOUGH_DATA (4)
             //I will not dispatch this event if readystate is 4 !
-            if (this._onDurationChange !== null && element.readyState === 1)
+            if (this._onDurationChange !== null && element.readyState === HTMLMediaElement.HAVE_METADATA)
             {
                 this._onDurationChange.dispatch(event);
             }
@@ -1804,10 +1804,10 @@ FORGE.VideoHTML5.prototype._onEventHandler = function(event)
             break;
 
         case "volumechange":
-            //I do not dispatch the volume change if readyState is 0. Because
+            //I do not dispatch the volume change if readyState is HAVE_NOTHING (0). Because
             //I set the volume at 0 when I create the video element, it is
             //not usefull to dispatch this internal volume change ?
-            if (this._onVolumeChange !== null && element.readyState !== 0)
+            if (this._onVolumeChange !== null && element.readyState !== HTMLMediaElement.HAVE_NOTHING)
             {
                 this._onVolumeChange.dispatch(event);
             }

--- a/src/display/video/VideoHTML5.js
+++ b/src/display/video/VideoHTML5.js
@@ -1315,7 +1315,6 @@ FORGE.VideoHTML5.prototype._setCurrentIndex = function(index, sync)
     //Resume playback if it was already playing
     if (this._playing === true)
     {
-        requestedVideo.element.currentTime = this.currentTime;
         requestedVideo.element.play();
     }
 

--- a/src/media/Media.js
+++ b/src/media/Media.js
@@ -155,7 +155,7 @@ FORGE.Media.prototype._parseConfig = function(config)
             source.url = [];
             for (var i = 0, ii = source.levels.length; i < ii; i++)
             {
-                if(FORGE.Device.deviceCheck(source.levels[i].device) === false)
+                if(FORGE.Device.check(source.levels[i].device) === false)
                 {
                     continue;
                 }

--- a/src/media/Media.js
+++ b/src/media/Media.js
@@ -198,6 +198,7 @@ FORGE.Media.prototype._onLoadedMetaDataHandler = function()
     {
         this._displayObject.volume = (typeof this._options.volume === "number") ? this._options.volume : 1;
         this._displayObject.loop = (typeof this._options.loop === "boolean") ? this._options.loop : true;
+        this._displayObject.currentTime = (typeof this._options.startTime === "number") ? this._options.startTime : 0;
 
         if (this._options.autoPlay === true)
         {

--- a/src/media/Media.js
+++ b/src/media/Media.js
@@ -88,13 +88,20 @@ FORGE.Media.prototype._parseConfig = function(config)
     // media configuration
     var mediaConfig = config.media;
 
-    if (typeof mediaConfig === "undefined")
+    if (typeof mediaConfig === "undefined" || mediaConfig === null)
     {
         return;
     }
 
-    // Warning : UID is not registered and applied to the FORGE.ImageScalable|FORGE.Image|FORGE.VideoHTML5|FORGE.VideoDash objects for registration
+    // Warning : UID is not registered and will be applied to the FORGE.ImageScalable|FORGE.Image|FORGE.VideoHTML5|FORGE.VideoDash objects for registration
     this._uid = mediaConfig.uid;
+
+    this._options = (typeof mediaConfig.options !== "undefined") ? mediaConfig.options : null;
+
+    if (typeof mediaConfig.source === "undefined" || mediaConfig.source === null)
+    {
+        return;
+    }
 
     var source = mediaConfig.source;
 
@@ -148,8 +155,18 @@ FORGE.Media.prototype._parseConfig = function(config)
             source.url = [];
             for (var i = 0, ii = source.levels.length; i < ii; i++)
             {
+                if(FORGE.Device.deviceCheck(source.levels[i].device) === false)
+                {
+                    continue;
+                }
+
                 source.url.push(source.levels[i].url);
             }
+        }
+
+        if (typeof source.url !== "string" && source.url.length === 0)
+        {
+            return;
         }
 
         if (typeof source.streaming !== "undefined" && source.streaming.toLowerCase() === FORGE.VideoFormat.DASH)
@@ -168,8 +185,6 @@ FORGE.Media.prototype._parseConfig = function(config)
 
         this._displayObject.onLoadedMetaData.addOnce(this._onLoadedMetaDataHandler, this);
     }
-
-    this._options = (typeof mediaConfig.options !== "undefined") ? mediaConfig.options : null;
 };
 
 /**

--- a/src/plugin/PluginEngine.js
+++ b/src/plugin/PluginEngine.js
@@ -331,7 +331,7 @@ FORGE.PluginEngine.prototype._parseManifest = function(manifest)
         return;
     }
 
-    if(FORGE.Device.deviceCheck(manifest.device) === false)
+    if(FORGE.Device.check(manifest.device) === false)
     {
         this.warn("Device compatibility check for plugin "+manifest.uid+" failed!");
         this.warn(manifest.device);

--- a/src/plugin/PluginEngine.js
+++ b/src/plugin/PluginEngine.js
@@ -331,7 +331,7 @@ FORGE.PluginEngine.prototype._parseManifest = function(manifest)
         return;
     }
 
-    if(this._deviceCheck(manifest.device) === false)
+    if(FORGE.Device.deviceCheck(manifest.device) === false)
     {
         this.warn("Device compatibility check for plugin "+manifest.uid+" failed!");
         this.warn(manifest.device);
@@ -422,36 +422,6 @@ FORGE.PluginEngine.prototype._versionCheck = function(config)
     if(viewerN < minN || viewerN > maxN)
     {
         return false;
-    }
-
-    return true;
-};
-
-/**
- * Check device requirement for this plugin engine.
- * @method FORGE.PluginEngine#_deviceCheck
- * @private
- * @param  {Object} config - The device requirement configuration object of the manifest.
- * @return {boolean} Returns true if the plugin is compatible with the device environment, false if not.
- */
-FORGE.PluginEngine.prototype._deviceCheck = function(config)
-{
-    //If configuration is undefined I guess that the plugin has no device limitations
-    if(typeof config === "undefined")
-    {
-        return true;
-    }
-
-    for(var i in config)
-    {
-        if(typeof FORGE.Device[i] === "undefined")
-        {
-            this.warn("Unable to check plugin device compatibility for: "+i);
-        }
-        else if(FORGE.Device[i] !== config[i])
-        {
-            return false;
-        }
     }
 
     return true;

--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -970,11 +970,11 @@ FORGE.Device = (function(c)
 
     /**
      * Check device requirement for an object from configuration/manifest.
-     * @method FORGE.Device#deviceCheck
+     * @method FORGE.Device#check
      * @param  {Object} config - The device requirement configuration of the configuration/manifest.
      * @return {boolean} Returns true if the object is compatible with the device environment, false if not.
      */
-    Tmp.prototype.deviceCheck = function(config)
+    Tmp.prototype.check = function(config)
     {
         //If configuration is undefined, the object has no device limitations
         if(typeof config === "undefined")

--- a/src/system/Device.js
+++ b/src/system/Device.js
@@ -968,6 +968,35 @@ FORGE.Device = (function(c)
             });
     };
 
+    /**
+     * Check device requirement for an object from configuration/manifest.
+     * @method FORGE.Device#deviceCheck
+     * @param  {Object} config - The device requirement configuration of the configuration/manifest.
+     * @return {boolean} Returns true if the object is compatible with the device environment, false if not.
+     */
+    Tmp.prototype.deviceCheck = function(config)
+    {
+        //If configuration is undefined, the object has no device limitations
+        if(typeof config === "undefined")
+        {
+            return true;
+        }
+
+        for(var i in config)
+        {
+            if(typeof this[i] === "undefined")
+            {
+                this.warn("Unable to check plugin device compatibility for: "+i);
+            }
+            else if(this[i] !== config[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    };
+
     return new Tmp();
 
 })(function()

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -152,11 +152,11 @@ FORGE.URL.exists = function(url, success, fail, context)
     var xhr = new XMLHttpRequest();
     var exists = false;
     var timeout = null;
-    
+
     /** @this {XMLHttpRequest} */
-    xhr.onreadystatechange = function() 
+    xhr.onreadystatechange = function()
     {
-        if(this.readyState === 4)
+        if(this.readyState === XMLHttpRequest.DONE)
         {
             if(this.status === 200)
             {
@@ -165,10 +165,10 @@ FORGE.URL.exists = function(url, success, fail, context)
 
                 if(typeof success === "function")
                 {
-                    success.call(context); 
+                    success.call(context);
                 }
-                
-            }  
+
+            }
         }
     };
 
@@ -184,16 +184,16 @@ FORGE.URL.exists = function(url, success, fail, context)
     {
         if(typeof fail === "function")
         {
-            fail.call(context); 
+            fail.call(context);
         }
-        
+
     };
 
     timeout = window.setTimeout(timeoutCallback, 500);
 };
 
 /**
- * Check if a URL is valid. 
+ * Check if a URL is valid.
  * Works only for absolute URLs.
  * @method  FORGE.URL.isValid
  * @param  {string} url - The URL to test.
@@ -202,8 +202,8 @@ FORGE.URL.exists = function(url, success, fail, context)
 FORGE.URL.isValid = function(url)
 {
     var urlRegEx = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-]*)?\??(?:[\-\+=&;%@\.\w]*)#?(?:[\.\!\/\\\w]*))?)/;
-      
-    if(!urlRegEx.test(url)) 
+
+    if(!urlRegEx.test(url))
     {
         return false;
     }
@@ -217,7 +217,7 @@ FORGE.URL.isValid = function(url)
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "url", 
+Object.defineProperty(FORGE.URL.prototype, "url",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -232,7 +232,7 @@ Object.defineProperty(FORGE.URL.prototype, "url",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "protocol", 
+Object.defineProperty(FORGE.URL.prototype, "protocol",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -247,7 +247,7 @@ Object.defineProperty(FORGE.URL.prototype, "protocol",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "host", 
+Object.defineProperty(FORGE.URL.prototype, "host",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -262,7 +262,7 @@ Object.defineProperty(FORGE.URL.prototype, "host",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "port", 
+Object.defineProperty(FORGE.URL.prototype, "port",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -277,7 +277,7 @@ Object.defineProperty(FORGE.URL.prototype, "port",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "path", 
+Object.defineProperty(FORGE.URL.prototype, "path",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -292,7 +292,7 @@ Object.defineProperty(FORGE.URL.prototype, "path",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "query", 
+Object.defineProperty(FORGE.URL.prototype, "query",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -307,7 +307,7 @@ Object.defineProperty(FORGE.URL.prototype, "query",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "hash", 
+Object.defineProperty(FORGE.URL.prototype, "hash",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -322,7 +322,7 @@ Object.defineProperty(FORGE.URL.prototype, "hash",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "hashParameters", 
+Object.defineProperty(FORGE.URL.prototype, "hashParameters",
 {
     /** @this {FORGE.URL} */
     get: function()
@@ -337,7 +337,7 @@ Object.defineProperty(FORGE.URL.prototype, "hashParameters",
  * @readonly
  * @type {string}
  */
-Object.defineProperty(FORGE.URL.prototype, "extension", 
+Object.defineProperty(FORGE.URL.prototype, "extension",
 {
     /** @this {FORGE.URL} */
     get: function()

--- a/tools/changelog/0.9.1.md
+++ b/tools/changelog/0.9.1.md
@@ -5,17 +5,19 @@
 - Change the way we detect Safari browser in FORGE.Device
 - Fix default background configuration for the main container
 
-### Media
-
-- New: Add a new media type "grid" to generate a grid preview with optional parameters
-
 ### Scene
 
 - Fix background configuration on scenes
 
+### Media
+
+- New: Add a new media type "grid" to generate a grid preview with optional parameters
+- New: Add a device options for video media with levels to match devices requirements
+
 ### Renderer
 
-- Don't update texture when the video is paused
+- Don't update video texture when the video is paused
+- Don't render the background when a scene has no media
 - Unload scene background on scene exit
 - Fix onBeforeRender and onAfterRender events on Hotspot3D objects
 
@@ -28,9 +30,9 @@
 
 - Redesign of the HTMLAudioElement loader to solve events never fired on Microsoft Edge
 
-### Open-source
+### Video
 
-- Add a template for GitHub issues
+- Fix multiple quality issues on Microsoft browsers.
 
 ### Plugins
 
@@ -48,6 +50,10 @@
 - Sample: Update all samples with video files with SafariCORS and MobileVideoPlay plugins
 
 - Tutorials: New tutorial for scene media
+
+### Open-source
+
+- Add a template for GitHub issues
 
 ### Misc
 


### PR DESCRIPTION
Update the multi-qualities managment for Firefox, Edge, IE11 compatibility.

Fixes :
- solve the frequent timeout event on MS browsers when requesting a quality
- second try added when a video quality request is aborted due to timeout
- add a downgrade counter to force the quality change only if the video is really "freezed"

Feature :
- add a startTime option for the media into JSON configuration to be able to set the currentTime of the video on start