### PR TITLE
Quick fix for video and page visibility

### DIFF
--- a/src/display/video/VideoBase.js
+++ b/src/display/video/VideoBase.js
@@ -112,7 +112,9 @@ FORGE.VideoBase.prototype.play = function(time, loop)
  * Pauses the video.
  * @method  FORGE.VideoBase#pause
  */
-FORGE.VideoBase.prototype.pause = function() {};
+FORGE.VideoBase.prototype.pause = function()
+{
+};
 
 /**
  * Destroy sequence.

--- a/src/display/video/VideoDash.js
+++ b/src/display/video/VideoDash.js
@@ -1773,6 +1773,7 @@ FORGE.VideoDash.prototype.stop = function()
         this._dashMediaPlayer.seek(0);
         this._video.element.currentTime = 0;
         this._playing = false;
+        this._paused = true;
     }
 };
 

--- a/src/display/video/VideoHTML5.js
+++ b/src/display/video/VideoHTML5.js
@@ -1938,6 +1938,7 @@ FORGE.VideoHTML5.prototype.stop = function()
         currentVideo.element.pause();
         currentVideo.element.currentTime = 0;
         this._playing = false;
+        this._paused = true;
     }
 };
 


### PR DESCRIPTION
When a video was stopped (and not paused), leaving the window as trigerring the Page Visibility API (as expected), but it was playing the video again. It is not the case anymore, there was the
this._paused flag that was badly set.