### PR TITLE
Fix WebVR bad scene loading

### DIFF
--- a/src/story/Story.js
+++ b/src/story/Story.js
@@ -450,13 +450,20 @@ FORGE.Story.prototype.loadScene = function(value)
         this._viewer.renderer.pickingManager.stop();
 
         // Readd it when the background is ready again
-        this._viewer.renderer.onBackgroundReady.addOnce(function()
-        {
-            this._viewer.renderer.pickingManager.start();
-        }, this);
+        this._viewer.renderer.onBackgroundReady.addOnce(this._onBackgroundReadyHandler, this);
 
         this._loadUid(uid);
     }
+};
+
+/**
+ * Handler for the onBackgroundReady event of the FORGE.Scene that is being loaded.
+ * @method FORGE.Story#_onBackgroundReadyHandler
+ * @private
+ */
+FORGE.Story.prototype._onBackgroundReadyHandler = function()
+{
+    this._viewer.renderer.pickingManager.start();
 };
 
 /**

--- a/src/story/Story.js
+++ b/src/story/Story.js
@@ -446,6 +446,15 @@ FORGE.Story.prototype.loadScene = function(value)
     //If uid is defined and if it's not the current scene
     if(typeof uid !== "undefined" && uid !== this._sceneUid)
     {
+        // Disable picking while the scene is loading
+        this._viewer.renderer.pickingManager.stop();
+
+        // Readd it when the background is ready again
+        this._viewer.renderer.onBackgroundReady.addOnce(function()
+        {
+            this._viewer.renderer.pickingManager.start();
+        }, this);
+
         this._loadUid(uid);
     }
 };


### PR DESCRIPTION
When the network was slow, in WebVR, loading a new scene (apart from the default one) could trigger the reload of the previous scene. It was cause by the gaze which was already working before the background was even up.

So now, the PickingManager is stopped when loading a new scene, until readded when the background of the next scene is ready.