### PR TITLE
Alps 649 scene events

### DIFF
--- a/reference/scene/scene-events.json
+++ b/reference/scene/scene-events.json
@@ -1,0 +1,49 @@
+{
+    "id": "scene-events",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "SceneEventsConfig",
+    "description": "An instance of <a href=\"#scene-events\">the scene events configuration</a>.",
+    "type": "object",
+
+    "properties": {
+        "onLoadStart": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onLoadStart",
+            "description": "The onLoadStart event of the scene. The action uid or an array of action uids",
+            "example": "action-0"
+        },
+
+        "onLoadComplete": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onLoadComplete",
+            "description": "The onLoadComplete event of the scene. The action uid or an array of action uids",
+            "example": "action-0"
+        },
+
+        "onUnloadStart": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onUnloadStart",
+            "description": "The onUnloadStart event of the scene. The action uid or an array of action uids",
+            "example": "action-0"
+        },
+
+        "onUnloadComplete": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onUnloadComplete",
+            "description": "The onUnloadComplete event of the scene. The action uid or an array of action uids",
+            "example": "action-0"
+        }
+    }
+}

--- a/reference/scene/scene.json
+++ b/reference/scene/scene.json
@@ -106,6 +106,10 @@
 
         "plugins": {
             "$ref": "plugin"
+        },
+
+        "events": {
+            "$ref": "scene-events"
         }
     }
 }

--- a/reference/story/story-events.json
+++ b/reference/story/story-events.json
@@ -1,0 +1,49 @@
+{
+    "id": "story-events",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "StoryEventsConfig",
+    "description": "An instance of <a href=\"#story-events\">the story events configuration</a>.",
+    "type": "object",
+
+    "properties": {
+        "onReady": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onReady",
+            "description": "The onReady event of the story. The action uid or an array of action uids",
+            "example": "action-0"
+        },
+
+        "onGroupChange": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onGroupChange",
+            "description": "The onGroupChange event of the story. The action uid or an array of action uids",
+            "example": "action-0"
+        },
+
+        "onSceneLoadStart": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onSceneLoadStart",
+            "description": "The onSceneLoadStart event of the story. The action uid or an array of action uids",
+            "example": "action-0"
+        },
+
+        "onSceneLoadComplete": {
+            "anyOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+            ],
+            "title": "onSceneLoadComplete",
+            "description": "The onSceneLoadComplete event of the story. The action uid or an array of action uids",
+            "example": "action-0"
+        }
+    }
+}

--- a/reference/story/story.json
+++ b/reference/story/story.json
@@ -66,6 +66,10 @@
             "items": {
                 "$ref": "group"
             }
+        },
+
+        "events": {
+            "$ref": "story-events"
         }
     },
 

--- a/src/3d/Object3D.js
+++ b/src/3d/Object3D.js
@@ -154,7 +154,7 @@ FORGE.Object3D.prototype._createEvents = function(events)
  * @method FORGE.Object3D#_clearEvents
  * @private
  */
-FORGE.Plugin.prototype._clearEvents = function()
+FORGE.Object3D.prototype._clearEvents = function()
 {
     for(var e in this._events)
     {

--- a/src/3d/Object3D.js
+++ b/src/3d/Object3D.js
@@ -150,6 +150,20 @@ FORGE.Object3D.prototype._createEvents = function(events)
 };
 
 /**
+ * Clear all object events.
+ * @method FORGE.Object3D#_clearEvents
+ * @private
+ */
+FORGE.Plugin.prototype._clearEvents = function()
+{
+    for(var e in this._events)
+    {
+        this._events[e].destroy();
+        this._events[e] = null;
+    }
+};
+
+/**
  * Triggers actions for the click event
  * @method FORGE.Object3D#click
  */
@@ -258,6 +272,9 @@ FORGE.Object3D.prototype.destroy = function()
         this._onReady.destroy();
         this._onReady = null;
     }
+
+    this._clearEvents();
+    this._events = null;
 
     this._viewer = null;
 

--- a/src/actions/Action.js
+++ b/src/actions/Action.js
@@ -204,10 +204,14 @@ FORGE.Action.prototype._parseTarget = function(target)
 
         var i = 0;
         // If it is the viewer, reset the result to it
-        if (path[0].toLowerCase() === "viewer")
+        if (path[0].toLowerCase() === "viewer" && result === null)
         {
             result = this._viewer;
             i = 1;
+        }
+        else if (result === null)
+        {
+            result = window;
         }
 
         for (var ii = path.length; i < ii; i++)

--- a/src/plugin/Plugin.js
+++ b/src/plugin/Plugin.js
@@ -415,11 +415,7 @@ FORGE.Plugin.prototype.destroy = function()
         this._onInstanceReady = null;
     }
 
-    var count = this._events.length;
-    while(count--)
-    {
-        this._events[count].destroy();
-    }
+    this._clearEvents();
     this._events = null;
 
     this._viewer = null;

--- a/src/story/Group.js
+++ b/src/story/Group.js
@@ -93,7 +93,6 @@ FORGE.Group = function(viewer, config)
     FORGE.BaseObject.call(this, "Group");
 
     this._boot();
-
 };
 
 FORGE.Group.prototype = Object.create(FORGE.BaseObject.prototype);
@@ -221,7 +220,6 @@ FORGE.Group.prototype.load = function(value)
     {
         throw "Impossible to load group child with uid " + uid + ", it seems to be neither a scene or a group!";
     }
-
 };
 
 /**
@@ -351,23 +349,9 @@ FORGE.Group.prototype.getChildrenUids = function(className)
     }
 
     var children = [];
-    //var child;
 
     for (var i = 0, ii = this._children.length; i < ii; i++)
     {
-        /*
-        child = FORGE.UID.get(this._children[i]);
-
-        if(typeof child === "undefined" || child === null)
-        {
-            continue;
-        }
-
-        if(child.className === className)
-        {
-            children.push(this._children[i]);
-        }*/
-
         if (FORGE.UID.isTypeOf(this._children[i], className))
         {
             children.push(this._children[i]);

--- a/src/story/Scene.js
+++ b/src/story/Scene.js
@@ -104,22 +104,10 @@ FORGE.Scene = function(viewer)
     this._onConfigLoadComplete = null;
 
     FORGE.BaseObject.call(this, "Scene");
-
-    // this._boot();
 };
 
 FORGE.Scene.prototype = Object.create(FORGE.BaseObject.prototype);
 FORGE.Scene.prototype.constructor = FORGE.Scene;
-
-/**
- * Boot sequence.
- * @method FORGE.Scene#_boot
- * @private
- */
-FORGE.Scene.prototype._boot = function()
-{
-    this.log("FORGE.Scene._boot();");
-};
 
 /**
  * Parse scene configuration.

--- a/src/story/Story.js
+++ b/src/story/Story.js
@@ -318,7 +318,7 @@ FORGE.Story.prototype._parseConfig = function(config)
  * Create events dispatchers.
  * @method FORGE.Story#_createEvents
  * @private
- * @param {Object=} events - The events config of the scene.
+ * @param {StoryEventsConfig} events - The events config of the story.
  */
 FORGE.Story.prototype._createEvents = function(events)
 {

--- a/src/story/Story.js
+++ b/src/story/Story.js
@@ -88,12 +88,12 @@ FORGE.Story = function(viewer)
     this._groupUid = "";
 
     /**
-     * Scene events from the json configuration
+     * Story events from the json configuration
      * @name FORGE.Story#_events
      * @type {Object<FORGE.ActionEventDispatcher>}
      * @private
      */
-    this._events = null;
+    this._events = {};
 
     /**
      * On ready event dispatcher
@@ -322,8 +322,6 @@ FORGE.Story.prototype._parseConfig = function(config)
  */
 FORGE.Story.prototype._createEvents = function(events)
 {
-    this._events = {};
-
     var event;
     for(var e in events)
     {

--- a/src/story/Story.js
+++ b/src/story/Story.js
@@ -320,7 +320,7 @@ FORGE.Story.prototype._parseConfig = function(config)
  * @private
  * @param {Object=} events - The events config of the scene.
  */
-FORGE.Plugin.prototype._createEvents = function(events)
+FORGE.Story.prototype._createEvents = function(events)
 {
     this._events = {};
 
@@ -338,7 +338,7 @@ FORGE.Plugin.prototype._createEvents = function(events)
  * @method FORGE.Story#_clearEvents
  * @private
  */
-FORGE.Plugin.prototype._clearEvents = function()
+FORGE.Story.prototype._clearEvents = function()
 {
     for(var e in this._events)
     {

--- a/src/story/Story.js
+++ b/src/story/Story.js
@@ -65,7 +65,7 @@ FORGE.Story = function(viewer)
 
     /**
      * Uid of the current scene.
-     * @name  FORGE.Story#_sceneUid
+     * @name FORGE.Story#_sceneUid
      * @type {string}
      * @private
      */
@@ -81,15 +81,23 @@ FORGE.Story = function(viewer)
 
     /**
      * Uid of the current group.
-     * @name  FORGE.Story#_groupUid
+     * @name FORGE.Story#_groupUid
      * @type {?string}
      * @private
      */
     this._groupUid = "";
 
     /**
+     * Scene events from the json configuration
+     * @name FORGE.Story#_events
+     * @type {Object<FORGE.ActionEventDispatcher>}
+     * @private
+     */
+    this._events = null;
+
+    /**
      * On ready event dispatcher
-     * @name  FORGE.Story#_onReady
+     * @name FORGE.Story#_onReady
      * @type {FORGE.EventDispatcher}
      * @private
      */
@@ -105,7 +113,7 @@ FORGE.Story = function(viewer)
 
     /**
      * On scene load progress event dispatcher.
-     * @name  FORGE.Story#_onSceneLoadProgress
+     * @name FORGE.Story#_onSceneLoadProgress
      * @type {FORGE.EventDispatcher}
      * @private
      */
@@ -113,7 +121,7 @@ FORGE.Story = function(viewer)
 
     /**
      * On scene load complete event dispatcher.
-     * @name  FORGE.Story#_onSceneLoadComplete
+     * @name FORGE.Story#_onSceneLoadComplete
      * @type {FORGE.EventDispatcher}
      * @private
      */
@@ -121,7 +129,7 @@ FORGE.Story = function(viewer)
 
     /**
      * On scene load error event dispatcher.
-     * @name  FORGE.Story#_onSceneLoadError
+     * @name FORGE.Story#_onSceneLoadError
      * @type {FORGE.EventDispatcher}
      * @private
      */
@@ -129,7 +137,7 @@ FORGE.Story = function(viewer)
 
     /**
      * On scene preview event dispatcher.
-     * @name  FORGE.Story#_onScenePreview
+     * @name FORGE.Story#_onScenePreview
      * @type {FORGE.EventDispatcher}
      * @private
      */
@@ -137,7 +145,7 @@ FORGE.Story = function(viewer)
 
     /**
      * On group change event dispatcher.
-     * @name  FORGE.Story#_onGroupChange
+     * @name FORGE.Story#_onGroupChange
      * @type {FORGE.EventDispatcher}
      * @private
      */
@@ -298,7 +306,45 @@ FORGE.Story.prototype._parseConfig = function(config)
         this._createGroups(this._config.groups);
     }
 
+    if(typeof this._config.events === "object" && this._config.events !== null)
+    {
+        this._createEvents(this._config.events);
+    }
+
     this._checkStoryScenes();
+};
+
+/**
+ * Create events dispatchers.
+ * @method FORGE.Story#_createEvents
+ * @private
+ * @param {Object=} events - The events config of the scene.
+ */
+FORGE.Plugin.prototype._createEvents = function(events)
+{
+    this._events = {};
+
+    var event;
+    for(var e in events)
+    {
+        event = new FORGE.ActionEventDispatcher(this._viewer, e);
+        event.addActions(events[e]);
+        this._events[e] = event;
+    }
+};
+
+/**
+ * Clear all events.
+ * @method FORGE.Story#_clearEvents
+ * @private
+ */
+FORGE.Plugin.prototype._clearEvents = function()
+{
+    for(var e in this._events)
+    {
+        this._events[e].destroy();
+        this._events[e] = null;
+    }
 };
 
 /**
@@ -324,6 +370,11 @@ FORGE.Story.prototype._setStoryReady = function()
     if(this._onReady !== null)
     {
         this._onReady.dispatch();
+    }
+
+    if(FORGE.Utils.isTypeOf(this._events.onReady, "ActionEventDispatcher") === true)
+    {
+        this._events.onReady.dispatch();
     }
 
     // If slug name in URL load the associated object
@@ -493,6 +544,11 @@ FORGE.Story.prototype._sceneLoadStart = function(event)
             this._onGroupChange.dispatch();
         }
 
+        if(FORGE.Utils.isTypeOf(this._events.onGroupChange, "ActionEventDispatcher") === true)
+        {
+            this._events.onGroupChange.dispatch();
+        }
+
     }
     else if (scene.hasGroups() === true && scene.hasGroup(this._groupUid) === false)
     {
@@ -504,10 +560,14 @@ FORGE.Story.prototype._sceneLoadStart = function(event)
         this._onSceneLoadStart.dispatch({ uid: scene.uid });
     }
 
+    if(FORGE.Utils.isTypeOf(this._events.onSceneLoadStart, "ActionEventDispatcher") === true)
+    {
+        this._events.onSceneLoadStart.dispatch();
+    }
 };
 
 /**
- * Internal event handmer for scene load complete, re-dispatch the load complete event at the story level.
+ * Internal event handler for scene load complete, re-dispatch the load complete event at the story level.
  * @method FORGE.Story#_sceneLoadComplete
  * @private
  */
@@ -516,6 +576,11 @@ FORGE.Story.prototype._sceneLoadComplete = function()
     if(this._onSceneLoadComplete !== null)
     {
         this._onSceneLoadComplete.dispatch();
+    }
+
+    if(FORGE.Utils.isTypeOf(this._events.onSceneLoadComplete, "ActionEventDispatcher") === true)
+    {
+        this._events.onSceneLoadComplete.dispatch();
     }
 };
 
@@ -550,6 +615,11 @@ FORGE.Story.prototype._setGroupUid = function(uid)
         if(this._onGroupChange !== null)
         {
             this._onGroupChange.dispatch();
+        }
+
+        if(FORGE.Utils.isTypeOf(this._events.onGroupChange, "ActionEventDispatcher") === true)
+        {
+            this._events.onGroupChange.dispatch();
         }
     }
 };
@@ -666,6 +736,9 @@ FORGE.Story.prototype.destroy = function()
         this._onGroupChange.destroy();
         this._onGroupChange = null;
     }
+
+    this._clearEvents();
+    this._events = null;
 
     FORGE.BaseObject.prototype.destroy.call(this);
 };

--- a/tools/changelog/0.9.2.md
+++ b/tools/changelog/0.9.2.md
@@ -40,6 +40,10 @@
 - Fix: Hotspot scale fix, the scale used to be applied two times (on geometry then on mesh. Now it is only applied on the mesh).
 - Fix: Hotspot out method is now called properly.
 
+### Actions
+
+- New: Actions target is now `window` by default.
+
 ### Components
 
 - Fix: Textfield fontWeight property never set.

--- a/tools/changelog/0.9.2.md
+++ b/tools/changelog/0.9.2.md
@@ -4,8 +4,13 @@
 
 - New: Add of autoPause and autoResume options to listen the Page Visibility API which lets you know when a webpage is visible or in focus.
 
+### Story
+
+- New: new events declartion for story in the json configuration. Available events are: onReady, onGroupChange, onSceneLoadStart, onSceneLoadComplete
+
 ### Scene
 
+- New: new events declartion for scenes in the json configuration. Available events are: onLoadStart, onLoadComplete, onUnloadStart, onUnloadComplete
 
 ### Media
 

--- a/tools/reference/pages.json
+++ b/tools/reference/pages.json
@@ -97,7 +97,8 @@
             "title": "Story",
             "slug": "story",
             "schemas": [
-                "story"
+                "story",
+                "story-events"
             ]
         },
         {
@@ -109,7 +110,8 @@
                 "scene-media",
                 "scene-media-source",
                 "scene-media-level",
-                "scene-media-options"
+                "scene-media-options",
+                "scene-events"
             ]
         },
         {
@@ -343,7 +345,8 @@
             "slug": "st$",
             "description": "This is the main section of ForgeJS, describing each scene present in the story. It is essentially composed of <a href=\"#scene\">scenes</a> that can be put in <a href=\"#group\">groups</a>.",
             "schemas": [
-                "story"
+                "story",
+                "story-events"
             ]
         }]
     },
@@ -361,7 +364,8 @@
                 "scene-media",
                 "scene-media-source",
                 "scene-media-level",
-                "scene-media-options"
+                "scene-media-options",
+                "scene-events"
             ]
         }]
     },


### PR DESCRIPTION
## Add JSON events on Story.js and Scene.js

### Story can now declare these events in the JSON:

```js
"events":
{
    "onReady": "action-story-onReady",
    "onGroupChange": "action-story-onGroupChange",
    "onSceneLoadStart": "action-story-onSceneLoadStart",
    "onSceneLoadComplete": "action-story-onSceneLoadComplete"
}
```
### Scene can now declare these events in the JSON:

```js
"events":
{
        "onLoadStart": "action-scene-onLoadStart",
        "onLoadComplete": "action-scene-onLoadComplete",
        "onUnloadStart": "action-scene-onUnloadStart",
        "onUnloadComplete": "action-scene-onUnloadComplete"
}
```

### Actions

Actions have now window as the default target.
ActionEventDispatcher can now re-schedule the destroy call if it is called during event dispatch.

### Samples

You can test the new events with the `story-events` sample.
You can test if actions are still working with the `hotspots-states` and the `hotspots-actions` samples.

Thanks for reviewing :sunglasses: