### PR TITLE
Flat media without flat view

### DIFF
--- a/src/render/background/BackgroundMeshRenderer.js
+++ b/src/render/background/BackgroundMeshRenderer.js
@@ -133,8 +133,6 @@ FORGE.BackgroundMeshRenderer.prototype._boot = function()
     this._size = 2 * FORGE.RenderManager.DEPTH_FAR;
 
     this._subdivision = 32;
-
-    this._updateInternals();
 };
 
 /**

--- a/src/render/view/ViewFlat.js
+++ b/src/render/view/ViewFlat.js
@@ -79,7 +79,7 @@ FORGE.ViewFlat.prototype._updateViewParams = function()
         {
             var hfov = vfov * this._viewer.renderer.displayResolution.ratio;
             var texRatio = this._viewer.renderer.backgroundRenderer.textureSize.ratio;
-            this._yawMax = Math.max(0, (Math.PI * texRatio - hfov) * 0.5); // image
+            this._yawMax = Math.min(360, Math.max(0, (Math.PI * texRatio - hfov) * 0.5)); // image
             this._yawMin = -this._yawMax;
         }
         else
@@ -98,6 +98,8 @@ FORGE.ViewFlat.prototype._updateViewParams = function()
             this._pitchMin = FORGE.Math.degToRad(-180);
             this._pitchMax = FORGE.Math.degToRad(180);
         }
+
+        this._viewer.view.notifyChange();
     }
 
     // Mesh rendering in flat view is limited around -+ 20 degrees


### PR DESCRIPTION
Bug alps-820

Just try **multiple-media** sample, scene 3 "image-flat-scene". It was black, displaying nothing, without this code change. From now on, it should display a flat image on a plane geometry rendered by a perspective camera.
