### PR TITLE
Remove the debug logs on minification

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -710,8 +710,10 @@ module.exports = function(grunt)
     ]);
 
     // Build with closure compiler
-    grunt.registerTask("min", "Compile the source with closure compiler", function()
+    grunt.registerTask("min", "Compile the source with closure compiler", function(arg1)
     {
+        var debug = (arg1 === "debug");
+
         var tasks =
         [
             "gitinfo",
@@ -724,7 +726,7 @@ module.exports = function(grunt)
             "replace:log",
             "copy:license",
             "copy:closure",
-            "closureExport:build",
+            "closureExport:build:" + debug,
             "referenceConcat:build",
             "externsGeneration:build",
             "concat:closure",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ grunt build
 
 Build a minified build of ForgeJS:
 ```
-grunt min
+grunt min // without logs on FORGE.DEBUG = true
+grunt min:debug // with logs
 ```
 
 Generate the documentation and the json reference:


### PR DESCRIPTION
Add the option when building the minified version of FORGE to keep the debug logs. By default, logs are not kept, but they can be turned on by using `grunt min:debug`.