### PR TITLE
Rroux plugin warnings

### DIFF
--- a/src/FORGE.js
+++ b/src/FORGE.js
@@ -35,4 +35,4 @@ FORGE.DEBUG = false;
  * @type {boolean}
  * @const
  */
-FORGE.WARNING = false;
+FORGE.WARNING = true;

--- a/src/plugin/Plugin.js
+++ b/src/plugin/Plugin.js
@@ -366,7 +366,7 @@ FORGE.Plugin.prototype.resetInstance = function()
         }
         else
         {
-            this.warn("There is no reset function on plugin "+this._engine.uid);
+            this.log("There is no reset function on plugin "+this._engine.uid);
         }
     }
 };


### PR DESCRIPTION
Turn on warnings by default
Remove the warning about the plugin reset function