### PR TITLE
Rroux viewer config

### DIFF
--- a/reference/viewer/viewer.json
+++ b/reference/viewer/viewer.json
@@ -26,6 +26,13 @@
             "title": "Autoresume",
             "description": "Does any sound need to be resumed automatically when the page gains focus ?",
             "default": false
+        },
+
+        "update": {
+            "type": "string",
+            "title": "Update",
+            "description": "The method used to call the update method",
+            "example": "timeout"
         }
     }
 }

--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -23,7 +23,7 @@ FORGE.Viewer = function(parent, config, callbacks)
 
     /**
      * The main config of the FORGE project
-     * @type {MainConfig|string}
+     * @type {(MainConfig|string)}
      */
     this._mainConfig = config;
 
@@ -34,8 +34,7 @@ FORGE.Viewer = function(parent, config, callbacks)
      * @type {?ViewerConfig}
      * @private
      */
-    this._config = FORGE.Viewer.DEFAULT_CONFIG;
-
+    this._config = null;
 
     /**
      * Reference to the DisplayList manager
@@ -497,12 +496,7 @@ FORGE.Viewer.prototype._parseMainConfig = function(config)
  */
 FORGE.Viewer.prototype._parseConfig = function(config)
 {
-    this._config = FORGE.Utils.extendSimpleObject(FORGE.Viewer.DEFAULT_CONFIG, config);
-
-    // this._config.background = (typeof config !== "undefined" && typeof config.background === "string") ? config.background : FORGE.Viewer.DEFAULT_CONFIG.background;
-    // this._container.background = this._config.background;
-    // this._config.autoPause = (typeof config !== "undefined" && typeof config.autoPause === "boolean") ? config.autoPause : FORGE.Viewer.DEFAULT_CONFIG.autoPause;
-    // this._config.autoResume = (typeof config !== "undefined" && typeof config.autoResume === "boolean") ? config.autoResume : FORGE.Viewer.DEFAULT_CONFIG.autoResume;
+    this._config = /** @type {ViewerConfig} */ (FORGE.Utils.extendSimpleObject(FORGE.Viewer.DEFAULT_CONFIG, config));
 };
 
 /**
@@ -689,9 +683,6 @@ FORGE.Viewer.prototype.destroy = function()
      */
 
     this._raf.stop();
-
-    this._mainConfig = null;
-    this._config = null;
 
     this._parent = null;
 

--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -381,8 +381,6 @@ FORGE.Viewer.prototype._boot = function(callback)
         this._callbacks.boot.call();
     }
 
-    this._raf.start();
-
     this._ready = true;
 
     if (this._onReady !== null)
@@ -487,6 +485,8 @@ FORGE.Viewer.prototype._parseMainConfig = function(config)
     {
         this._story.load(config.story);
     }
+
+    this._raf.start();
 };
 
 /**

--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -22,16 +22,20 @@ FORGE.Viewer = function(parent, config, callbacks)
     this._parent = parent;
 
     /**
+     * The main config of the FORGE project
+     * @type {MainConfig|string}
+     */
+    this._mainConfig = config;
+
+    /**
      * The viewer configuration or its URL.
      * After the config loading it will be a MainConfig in all cases.
      * @name FORGE.Viewer#_config
-     * @type {?(MainConfig|string)}
+     * @type {?ViewerConfig}
      * @private
      */
-    this._config = config ||
-    {
-        viewer: FORGE.Viewer.DEFAULT_CONFIG
-    };
+    this._config = FORGE.Viewer.DEFAULT_CONFIG;
+
 
     /**
      * Reference to the DisplayList manager
@@ -302,7 +306,8 @@ FORGE.Viewer.prototype.constructor = FORGE.Viewer;
  * @type {MainConfig}
  * @const
  */
-FORGE.Viewer.DEFAULT_CONFIG = {
+FORGE.Viewer.DEFAULT_CONFIG =
+{
     background: "#000",
     autoResume: true,
     autoPause: true
@@ -385,7 +390,7 @@ FORGE.Viewer.prototype._boot = function(callback)
         this._onReady.dispatch();
     }
 
-    this._loadConfig(this._config);
+    this._loadConfig(this._mainConfig);
 };
 
 /**
@@ -398,7 +403,7 @@ FORGE.Viewer.prototype._loadConfig = function(config)
 {
     if (typeof config === "string")
     {
-        this._load.json(this._uid + "-configuration", config, this._configLoadComplete, this);
+        this._load.json(this._uid + "-configuration", config, this._mainConfigLoadComplete, this);
     }
     else if (config !== null && typeof config === "object")
     {
@@ -408,13 +413,13 @@ FORGE.Viewer.prototype._loadConfig = function(config)
 
 /**
  * Event handler for the configuration JSON load complete.
- * @method FORGE.Story#_configLoadComplete
+ * @method FORGE.Story#_mainConfigLoadComplete
  * @param  {FORGE.File} file - The {@link FORGE.File} that describes the loaded JSON file.
  * @private
  */
-FORGE.Viewer.prototype._configLoadComplete = function(file)
+FORGE.Viewer.prototype._mainConfigLoadComplete = function(file)
 {
-    this.log("FORGE.Viewer._configLoadComplete();");
+    this.log("FORGE.Viewer._mainConfigLoadComplete();");
 
     var json = this._cache.get(FORGE.Cache.types.JSON, file.key);
     var config = /** @type {MainConfig} */ (json.data);
@@ -430,7 +435,7 @@ FORGE.Viewer.prototype._configLoadComplete = function(file)
 FORGE.Viewer.prototype._parseMainConfig = function(config)
 {
     // Final assignement of the config
-    this._config = config;
+    this._mainConfig = config;
 
     this._parseConfig(config.viewer);
 
@@ -492,10 +497,12 @@ FORGE.Viewer.prototype._parseMainConfig = function(config)
  */
 FORGE.Viewer.prototype._parseConfig = function(config)
 {
-    this._config.background = (typeof config !== "undefined" && typeof config.background === "string") ? config.background : FORGE.Viewer.DEFAULT_CONFIG.background;
-    this._container.background = this._config.background;
-    this._config.autoPause = (typeof config !== "undefined" && typeof config.autoPause === "boolean") ? config.autoPause : FORGE.Viewer.DEFAULT_CONFIG.autoPause;
-    this._config.autoResume = (typeof config !== "undefined" && typeof config.autoResume === "boolean") ? config.autoResume : FORGE.Viewer.DEFAULT_CONFIG.autoResume;
+    this._config = FORGE.Utils.extendSimpleObject(FORGE.Viewer.DEFAULT_CONFIG, config);
+
+    // this._config.background = (typeof config !== "undefined" && typeof config.background === "string") ? config.background : FORGE.Viewer.DEFAULT_CONFIG.background;
+    // this._container.background = this._config.background;
+    // this._config.autoPause = (typeof config !== "undefined" && typeof config.autoPause === "boolean") ? config.autoPause : FORGE.Viewer.DEFAULT_CONFIG.autoPause;
+    // this._config.autoResume = (typeof config !== "undefined" && typeof config.autoResume === "boolean") ? config.autoResume : FORGE.Viewer.DEFAULT_CONFIG.autoResume;
 };
 
 /**
@@ -673,6 +680,7 @@ FORGE.Viewer.prototype.destroy = function()
 
     this._raf.stop();
 
+    this._mainConfig = null;
     this._config = null;
 
     this._parent = null;
@@ -794,8 +802,23 @@ Object.defineProperty(FORGE.Viewer.prototype, "ready",
 
 /**
  * Get the main configuration.
- * @name FORGE.Viewer#config
+ * @name FORGE.Viewer#mainConfig
  * @type {MainConfig}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Viewer.prototype, "mainConfig",
+{
+    /** @this {FORGE.Viewer} */
+    get: function()
+    {
+        return this._mainConfig;
+    }
+});
+
+/**
+ * Get the viewer configuration.
+ * @name FORGE.Viewer#config
+ * @type {ViewerConfig}
  * @readonly
  */
 Object.defineProperty(FORGE.Viewer.prototype, "config",

--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -627,6 +627,11 @@ FORGE.Viewer.prototype.update = function(time)
  */
 FORGE.Viewer.prototype.pause = function(internal)
 {
+    if(this._paused === true)
+    {
+        return;
+    }
+
     this._paused = true;
 
     // Pause all media if autoPause is true
@@ -650,6 +655,11 @@ FORGE.Viewer.prototype.pause = function(internal)
  */
 FORGE.Viewer.prototype.resume = function(internal)
 {
+    if(this._paused === false)
+    {
+        return;
+    }
+
     this._paused = false;
 
     // Resume all media if autoResume is true

--- a/src/render/RenderManager.js
+++ b/src/render/RenderManager.js
@@ -325,7 +325,7 @@ FORGE.RenderManager.prototype._onSceneUnloadStartHandler = function()
 FORGE.RenderManager.prototype._initCamera = function(sceneConfig)
 {
     var sceneCameraConfig = /** @type {CameraConfig} */ (sceneConfig.camera);
-    var storyCameraConfig = /** @type {CameraConfig} */ (this._viewer.config.camera);
+    var storyCameraConfig = /** @type {CameraConfig} */ (this._viewer.mainConfig.camera);
     var extendedCameraConfig = /** @type {CameraConfig} */ (FORGE.Utils.extendMultipleObjects(storyCameraConfig, sceneCameraConfig));
 
     this._camera.load(extendedCameraConfig);

--- a/src/render/view/ViewManager.js
+++ b/src/render/view/ViewManager.js
@@ -131,7 +131,7 @@ FORGE.ViewManager.prototype.notifyChange = function()
 FORGE.ViewManager.prototype.load = function(config)
 {
     var sceneViewConfig = /** @type {ViewConfig} */ (config);
-    var globalViewConfig = /** @type {ViewConfig} */ (this._viewer.config.view);
+    var globalViewConfig = /** @type {ViewConfig} */ (this._viewer.mainConfig.view);
     var extendedViewConfig = /** @type {ViewConfig} */ (FORGE.Utils.extendMultipleObjects(globalViewConfig, sceneViewConfig));
 
     var type = (typeof extendedViewConfig.type === "string") ? extendedViewConfig.type.toLowerCase() : FORGE.ViewType.RECTILINEAR;


### PR DESCRIPTION
Fix the viewer config.
Now you can acces the viewer config via viewer.config and the global main config via viewer.mainConfig.

Fix the pause and resume methods + strarts the raf after the parse of the main config.