### PR TITLE
RenderPipeline / Postprocessing - add support of FX passes in JSON

### DIFF
--- a/src/render/postProcessing/EffectComposer.js
+++ b/src/render/postProcessing/EffectComposer.js
@@ -43,6 +43,14 @@ FORGE.EffectComposer = function(type, renderer, renderTarget)
      */
     this._enabled = true;
 
+    /**
+     * Sum of clock deltas.
+     * @name FORGE.ShaderPass#_deltaSum
+     * @type {number}
+     * @private
+     */
+    this._deltaSum = 0;
+
     THREE.EffectComposer.call(this, renderer, renderTarget);
 
     this._boot();
@@ -59,6 +67,36 @@ FORGE.EffectComposer.prototype.constructor = FORGE.EffectComposer;
 FORGE.EffectComposer.prototype._boot = function()
 {
     this._name = FORGE.EffectComposer.getUniqueName(this._type);
+};
+
+/**
+ * Render
+ * Set time for all passes
+ * @method FORGE.EffectComposer#render
+ */
+FORGE.EffectComposer.prototype.render = function(delta)
+{
+    this._deltaSum += delta;
+
+    var time = this._deltaSum;
+    for (var i=0, ii=this.passes.length; i<ii; i++)
+    {
+        var pass = this.passes[i];
+
+        if (typeof pass.uniforms !== "undefined")
+        {
+            if (typeof pass.uniforms.time !== "undefined")
+            {
+                pass.uniforms.time.value = time;
+            }
+        }
+
+        if (typeof pass.time !== "undefined")
+        {
+            pass.time = time;
+        }
+    }
+    THREE.EffectComposer.prototype.render.call(this, delta);
 };
 
 /**

--- a/src/render/postProcessing/EffectComposer.js
+++ b/src/render/postProcessing/EffectComposer.js
@@ -77,8 +77,8 @@ FORGE.EffectComposer.prototype._boot = function()
 FORGE.EffectComposer.prototype.render = function(delta)
 {
     this._deltaSum += delta;
-
     var time = this._deltaSum;
+
     for (var i=0, ii=this.passes.length; i<ii; i++)
     {
         var pass = this.passes[i];
@@ -96,6 +96,7 @@ FORGE.EffectComposer.prototype.render = function(delta)
             pass.time = time;
         }
     }
+    
     THREE.EffectComposer.prototype.render.call(this, delta);
 };
 

--- a/src/render/postProcessing/PostProcessing.js
+++ b/src/render/postProcessing/PostProcessing.js
@@ -73,6 +73,100 @@ FORGE.PostProcessing.prototype._parseConfig = function(config)
 };
 
 /**
+ * Parse shader config
+ * @method FORGE.PostProcessing#_parseShaderConfig
+ * @param {FX} shaderConfig - a shader configuration
+ * @return {THREE.Pass} pass to be added to the render pipeline
+ */
+FORGE.PostProcessing.prototype._parseShaderConfig = function(shaderConfig)
+{
+    var shader = THREE[shaderConfig.type];
+    var pass = new FORGE.ShaderPass(shaderConfig.uid, shaderConfig.type, shader);
+
+    if (typeof pass.uniforms !== "undefined")
+    {
+        for (var param in shaderConfig.params)
+        {
+            var paramValue = shaderConfig.params[param];
+            var value = paramValue;
+
+            // Check if param is an object to build
+            if (typeof paramValue === "object" && paramValue.hasOwnProperty("type") && paramValue.hasOwnProperty("args"))
+            {
+                var args = paramValue.args;
+                switch (paramValue.type)
+                {
+                    case "THREE.Color":
+                        if (args.length === 3)
+                        {
+                            value = new THREE.Color(args[0], args[1], args[2]);
+                        }
+                        else if (typeof args === "string" || typeof args === "number")
+                        {
+                            value = new THREE.Color(args);
+                        }
+                        else
+                        {
+                            throw new Error("Cannot create THREE.Color with " + (typeof args) + " (length " + args.length + ")");
+                        }
+                        break;
+
+                    case "THREE.Vector2":
+                        value = new THREE.Vector2(args[0], args[1]);
+                        break;
+
+                    case "THREE.Vector3":
+                        value = new THREE.Vector3(args[0], args[1], args[2]);
+                        break;
+                }
+            }
+
+            pass.uniforms[param].value = value;
+        }
+    }
+
+    return pass;
+};
+
+/**
+ * Parse shader config
+ * @method FORGE.PostProcessing#_parsePassConfig
+ * @param {FX} passConfig - a pass configuration
+ * @return {THREE.Pass} pass to be added to the render pipeline
+ */
+FORGE.PostProcessing.prototype._parsePassConfig = function(passConfig)
+{
+    var constructor = THREE[passConfig.type];
+
+    var args = [];
+    if (typeof passConfig.args !== "undefined")
+    {
+        // If args is an array, feed constructor with it, else create array from values if it's an object
+        if (passConfig.args instanceof Array)
+        {
+            args = [null].concat(passConfig.args);
+        }
+        else
+        {
+            args = [null].concat(Object.values(passConfig.args));
+        }
+    }
+
+    var pass = new (Function.prototype.bind.apply(constructor, args));
+    pass.uid = passConfig.uid;
+
+    if (typeof passConfig.params !== "undefined")
+    {
+        for (var param in passConfig.params)
+        {
+            pass[param] = passConfig.params[param];    
+        }        
+    }
+
+    return pass;
+};
+
+/**
  * Parse shader passes from FX configuration object
  * @method FORGE.PostProcessing#parseShaderPasses
  * @param {Array<FX>} fxConfig - a set of FX
@@ -87,13 +181,11 @@ FORGE.PostProcessing.prototype.parseShaderPasses = function(fxConfig)
         return [];
     }
 
-    var shaderPasses = [];
+    var passes = [];
 
     for (var j = 0, jj = fxConfig.length; j < jj; j++)
     {
         var fx = /** type {FX} */ (fxConfig[j]);
-
-        var pass = null;
 
         if (!THREE.hasOwnProperty(fx.type))
         {
@@ -101,55 +193,23 @@ FORGE.PostProcessing.prototype.parseShaderPasses = function(fxConfig)
             continue;
         }
 
-        var shader = THREE[fx.type];
-        pass = new FORGE.ShaderPass(fx.uid, fx.type, shader);
-
-        if (typeof pass.uniforms !== "undefined")
+        var pass = null;
+        if (fx.type.indexOf("Shader") != -1)
         {
-            for (var param in fx.params)
-            {
-                var paramValue = fx.params[param];
-                var value = paramValue;
-
-                // Check if param is an object to build
-                if (typeof paramValue === "object" && paramValue.hasOwnProperty("type") && paramValue.hasOwnProperty("args"))
-                {
-                    var args = paramValue.args;
-                    switch (paramValue.type)
-                    {
-                        case "THREE.Color":
-                            if (args.length === 3)
-                            {
-                                value = new THREE.Color(args[0], args[1], args[2]);
-                            }
-                            else if (typeof args === "string" || typeof args === "number")
-                            {
-                                value = new THREE.Color(args);
-                            }
-                            else
-                            {
-                                throw new Error("Cannot create THREE.Color with " + (typeof args) + " (length " + args.length + ")");
-                            }
-                            break;
-
-                        case "THREE.Vector2":
-                            value = new THREE.Vector2(args[0], args[1]);
-                            break;
-
-                        case "THREE.Vector3":
-                            value = new THREE.Vector3(args[0], args[1], args[2]);
-                            break;
-                    }
-                }
-
-                pass.uniforms[param].value = value;
-            }
+            pass = this._parseShaderConfig(fx);
+        }
+        else if (fx.type.indexOf("Pass") != -1)
+        {
+            pass = this._parsePassConfig(fx);
         }
 
-        shaderPasses.push(pass);
+        if (pass !== null)
+        {
+            passes.push(pass);
+        }
     }
 
-    return shaderPasses;
+    return passes;
 };
 
 /**

--- a/src/render/postProcessing/PostProcessing.js
+++ b/src/render/postProcessing/PostProcessing.js
@@ -148,7 +148,11 @@ FORGE.PostProcessing.prototype._parsePassConfig = function(passConfig)
         }
         else
         {
-            args = [null].concat(Object.values(passConfig.args));
+            args = [null];
+            for (var prop in passConfig.args)
+            {
+                args.push(passConfig.args[prop]);
+            }
         }
     }
 


### PR DESCRIPTION
Add passes to FX support in JSON.

Test case: fetch dev/projects in master branch and sources in alps-renderpipeline-support-user-passes

Open FORGE/dev/projects/fx and check FX presence