### PR TITLE
Fix animated hotspots destruction

### DIFF
--- a/src/hotspots/HotspotAnimation.js
+++ b/src/hotspots/HotspotAnimation.js
@@ -50,7 +50,7 @@ FORGE.HotspotAnimation = function(viewer, hotspot)
 
     /**
      * On animation progress event dispatcher.
-     * @name FORGE.MetaAnimation#_onProgress
+     * @name FORGE.HotspotAnimation#_onProgress
      * @type {FORGE.EventDispatcher}
      * @private
      */
@@ -351,6 +351,23 @@ FORGE.HotspotAnimation.prototype.play = function(track)
     this._animations[0].play();
     this._animations[1].play();
     this._animations[2].play();
+};
+
+/**
+ * Destroy sequence.
+ * @method FORGE.HotspotAnimation#destroy
+ */
+FORGE.HotspotAnimation.prototype.destroy = function()
+{
+    this._tracks = null;
+
+    if (this._onProgress !== null)
+    {
+        this._onProgress.destroy();
+        this._onProgress = null;
+    }
+
+    FORGE.MetaAnimation.prototype.destroy.call(this);
 };
 
 /**

--- a/src/timeline/MetaAnimation.js
+++ b/src/timeline/MetaAnimation.js
@@ -1,7 +1,7 @@
 /**
  * A meta-animation, used to provide basic functionnality for the interface
  * between an ObjectAnimation and FORGE.Animation.
- * 
+ *
  * @constructor FORGE.MetaAnimation
  * @param {FORGE.Viewer} viewer - {@link FORGE.Viewer} reference.
  * @param {*} target - Target reference.
@@ -210,6 +210,26 @@ FORGE.MetaAnimation.prototype._emptyAnimations = function()
  */
 FORGE.MetaAnimation.prototype.destroy = function()
 {
+    this._emptyAnimations();
+
+    this._animations = null;
+
+    var instruction;
+
+    while (this._instructions && this._instructions.length > 0)
+    {
+        instruction = this._instructions.pop();
+        instruction = null;
+    }
+
+    this._instructions = null;
+
+    if (this._onComplete !== null)
+    {
+        this._onComplete.destroy();
+        this._onComplete = null;
+    }
+
     FORGE.BaseObject.prototype.destroy.call(this);
 };
 


### PR DESCRIPTION
As reported on the forum (https://forum.forgejs.org/viewtopic.php?f=7&t=78#p241), there was a bug when switching scene with animated hotspots.

It was the fault of empty `destroy` methods, in `MetaAnimation` and `HotspotAnimation`.

Can be tested by duplicating the scene in the sample with the rabbit and the butterfly, and doing `nextScene`