### PR TITLE
Alps 816 - Missing destroy methods

### DIFF
--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -703,6 +703,9 @@ FORGE.Viewer.prototype.destroy = function()
 
     this._parent = null;
 
+    this._system.destroy();
+    this._system = null;
+
     this._plugins.destroy();
     this._plugins = null;
 

--- a/src/render/RenderManager.js
+++ b/src/render/RenderManager.js
@@ -927,18 +927,6 @@ FORGE.RenderManager.prototype.destroy = function()
         this._onBackgroundReady = null;
     }
 
-    if (this._onViewReady !== null)
-    {
-        this._onViewReady.destroy();
-        this._onViewReady = null;
-    }
-
-    if (this._onHotspotsReady !== null)
-    {
-        this._onHotspotsReady.destroy();
-        this._onHotspotsReady = null;
-    }
-
     if (this._mediaSound !== null)
     {
         this._mediaSound.destroy();
@@ -1202,26 +1190,6 @@ Object.defineProperty(FORGE.RenderManager.prototype, "onBackgroundReady",
 });
 
 /**
- * Get the onViewReady {@link FORGE.EventDispatcher}.
- * @name FORGE.RenderManager#onViewReady
- * @readonly
- * @type {FORGE.EventDispatcher}
- */
-Object.defineProperty(FORGE.RenderManager.prototype, "onViewReady",
-{
-    /** @this {FORGE.RenderManager} */
-    get: function()
-    {
-        if (this._onViewReady === null)
-        {
-            this._onViewReady = new FORGE.EventDispatcher(this, true);
-        }
-
-        return this._onViewReady;
-    }
-});
-
-/**
  * Get the objects
  * @name FORGE.RenderManager#objects
  * @type {FORGE.ObjectRenderer}
@@ -1248,25 +1216,5 @@ Object.defineProperty(FORGE.RenderManager.prototype, "hotspotsReady",
     get: function()
     {
         return this._hotspotsReady;
-    }
-});
-
-/**
- * Get the onHotspotsReady {@link FORGE.EventDispatcher}.
- * @name FORGE.RenderManager#onHotspotsReady
- * @type {FORGE.EventDispatcher}
- * @readonly
- */
-Object.defineProperty(FORGE.RenderManager.prototype, "onHotspotsReady",
-{
-    /** @this {FORGE.RenderManager} */
-    get: function()
-    {
-        if (this._onHotspotsReady === null)
-        {
-            this._onHotspotsReady = new FORGE.EventDispatcher(this, true);
-        }
-
-        return this._onHotspotsReady;
     }
 });

--- a/src/render/view/ViewManager.js
+++ b/src/render/view/ViewManager.js
@@ -163,6 +163,26 @@ FORGE.ViewManager.prototype.disableVR = function()
 };
 
 /**
+ * Destroy sequence
+ * @method FORGE.ViewManager#destroy
+ */
+FORGE.ViewManager.prototype.destroy = function()
+{
+    this._viewer = null;
+
+    this._view.destroy();
+    this._view = null;
+
+    if (this._onChange !== null)
+    {
+        this._onChange.destroy();
+        this._onChange = null;
+    }
+
+    FORGE.BaseObject.prototype.destroy.call(this);
+};
+
+/**
  * Get the current view object.
  * @name  FORGE.ViewManager#current
  * @type {FORGE.ViewBase}


### PR DESCRIPTION
- add a destroy for the ViewManager class
- remove blocking parts in the destroy of RenderManager (cf a bug on Slack)
- add the destroy of System in the Viewer destroy