### PR TITLE
Alps 871 camera limits

### DIFF
--- a/src/camera/Camera.js
+++ b/src/camera/Camera.js
@@ -37,7 +37,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._yawMin = -Infinity;
+    this._yawMin = 0;
 
     /**
      * The yaw maximum value in radians.
@@ -45,7 +45,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._yawMax = Infinity;
+    this._yawMax = 0;
 
     /**
      * The pitch value in radians.
@@ -61,7 +61,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._pitchMin = -Infinity;
+    this._pitchMin = 0;
 
     /**
      * The pitch maximum value  in radians.
@@ -69,7 +69,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._pitchMax = Infinity;
+    this._pitchMax = 0;
 
     /**
      * The roll value in radians.
@@ -85,7 +85,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._rollMin = -Infinity;
+    this._rollMin = 0;
 
     /**
      * The roll maximum value in radians.
@@ -93,7 +93,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._rollMax = Infinity;
+    this._rollMax = 0;
 
     /**
      * The fov value in radians.
@@ -101,7 +101,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._fov = Math.PI / 2;
+    this._fov = 0;
 
     /**
      * The fov minimum value in radians.
@@ -117,7 +117,7 @@ FORGE.Camera = function(viewer)
      * @type {number}
      * @private
      */
-    this._fovMax = Infinity;
+    this._fovMax = 0;
 
     /**
      * Parallax setting
@@ -242,18 +242,26 @@ FORGE.Camera.DEFAULT_CONFIG = {
     parallax: 0,
     yaw:
     {
-        default: 0
+        min: -Infinity,
+        max: Infinity,
+        default: 0,
     },
     pitch:
     {
+        min: -Infinity,
+        max: Infinity,
         default: 0
     },
     roll:
     {
+        min: -Infinity,
+        max: Infinity,
         default: 0
     },
     fov:
     {
+        min: 0,
+        max: Infinity,
         default: 90
     },
     gaze:


### PR DESCRIPTION
When setting camera limits in JSON config, changing scene results in a bad reinit of bounds according to view defines.

How to reproduce and understand the problem (and the fix)

- open mpeg-dash sample project
- edit the JSON config 
- add limits to the camera of scene 1: `"camera": { "fov": { "min": 90, "max": 180, "default": 90 } }`
- launch the project beginning with scene 1: http://dev/samples/projects/mpeg-dash/#second-scene&uid=scene-1
- open console and run instructions: `viewer.story.scene.uid + " -> " +  viewer.camera.fov + " [" + viewer.camera.fovMin + ", " + viewer.camera.fovMax + "]"`
- result should be as set in JSON: 
> "scene-1 -> 90 [90, 180]"
- jump to scene-0 with previous button and recall the same instructions line. Scene 0 JSON config does not override camera limits and should be set according to the view defaults: rectilinear [40°, 140°]. Thus result should be 
> "scene-0 -> 90 [40, 140]"

Without this bug fix, scene-0 outputs the following result:
> "scene-0 -> 90 [90, 140]"

Fov min is not restored to view default value (40°) and keeps JSON definition that should only impact scene 1.