### PR TITLE
Alps 589 - add support for gamepad controller

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,11 +131,16 @@ module.exports = function(grunt)
         "src/i18n/LocaleString.js",
         "src/i18n/Locale.js",
 
+        "src/input/binding/BaseBinding.js",
+        "src/input/binding/KeyBinding.js",
+        "src/input/binding/ButtonBinding.js",
+        "src/input/binding/AxisBinding.js",
         "src/input/Keyboard.js",
-        "src/input/KeyBinding.js",
         "src/input/Drag.js",
         "src/input/Pointer.js",
         "src/input/Gyroscope.js",
+        "src/input/GamepadsManager.js",
+        "src/input/Gamepad.js",
 
         "src/display/DisplayList.js",
         "src/display/DisplayObject.js",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,6 +101,7 @@ module.exports = function(grunt)
         "src/controllers/ControllerPointer.js",
         "src/controllers/ControllerKeyboard.js",
         "src/controllers/ControllerGyroscope.js",
+        "src/controllers/ControllerGamepad.js",
 
         "src/audio/SoundManager.js",
         "src/audio/SoundType.js",

--- a/externs/lib/w3c.gamepad-extension.ext.js
+++ b/externs/lib/w3c.gamepad-extension.ext.js
@@ -1,0 +1,62 @@
+/**
+ * Externs file for the Gamepad API extension, as it is a working draft and not implemented in
+ * the Closure Compiler.
+ * https://w3c.github.io/gamepad/extensions.html
+ */
+
+/**
+ * @constructor
+ * @return {GamepadHapticActuator}
+ */
+var GamepadHapticActuator = function() {};
+
+/** @type {string} */
+GamepadHapticActuator.prototype.type;
+
+/**
+ * @param {number} value
+ * @param {number} duration
+ * @return {Promise}
+ */
+GamepadHapticActuator.prototype.pulse = function(value, duration) {};
+
+/**
+ * @constructor
+ * @return {GamepadPose}
+ */
+var GamepadPose = function() {};
+
+/** @type {boolean} */
+GamepadPose.prototype.hasOrientation;
+
+/** @type {boolean} */
+GamepadPose.prototype.hasPosition;
+
+/** @type {?Float32Array} */
+GamepadPose.prototype.position;
+
+/** @type {?Float32Array} */
+GamepadPose.prototype.linearVelocity;
+
+/** @type {?Float32Array} */
+GamepadPose.prototype.linearAcceleration;
+
+/** @type {?Float32Array} */
+GamepadPose.prototype.orientation;
+
+/** @type {?Float32Array} */
+GamepadPose.prototype.angularVelocity;
+
+/** @type {?Float32Array} */
+GamepadPose.prototype.angularAcceleration;
+
+//// Partial interface
+
+/** @type {string} */
+Gamepad.prototype.hand;
+
+/** @type {GamepadHapticActuator} */
+Gamepad.prototype.hapticActuators;
+
+/** @type {?GamepadPose} */
+Gamepad.prototype.pose;

--- a/reference/controller/controller-gamepad-axis-binding-event.json
+++ b/reference/controller/controller-gamepad-axis-binding-event.json
@@ -1,0 +1,18 @@
+{
+    "id": "controller-gamepad-axis-binding-events",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ControllerGamepadAxisBindingEventsConfig",
+    "description": "Available events to bind actions to an axis for the <a href=\"#controller-gamepad\">controller gamepad.</a>",
+    "type": "object",
+
+    "properties": {
+        "onMove":{
+            "anyOf":[
+                {"type": "string"},
+                {"type": "array", "items": "string"}
+            ],
+            "title": "onMove",
+            "description": "The action or array of actions uid to trigger on axis down event"
+        }
+    }
+}

--- a/reference/controller/controller-gamepad-axis-binding-event.json
+++ b/reference/controller/controller-gamepad-axis-binding-event.json
@@ -6,12 +6,12 @@
     "type": "object",
 
     "properties": {
-        "onMove":{
+        "onChange":{
             "anyOf":[
                 {"type": "string"},
                 {"type": "array", "items": "string"}
             ],
-            "title": "onMove",
+            "title": "onChange",
             "description": "The action or array of actions uid to trigger on axis down event"
         }
     }

--- a/reference/controller/controller-gamepad-axis-binding.json
+++ b/reference/controller/controller-gamepad-axis-binding.json
@@ -1,0 +1,27 @@
+{
+    "id": "controller-gamepad-axis-binding",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ControllerGamepadAxisBindingConfig",
+    "description": "A custom <a href=\"#controller-gamepad-binding\">controller gamepad</a> axis binding.",
+    "type": "object",
+
+    "properties": {
+        "name":{
+            "type": "string",
+            "title": "Name",
+            "description": "The name of this axis binding"
+        },
+
+        "axis":{
+            "type": "number",
+            "title": "axis",
+            "description": "The axis code that is associated to this axis binding."
+        },
+
+        "events":{
+            "$ref": "controller-gamepad-axis-binding-events"
+        }
+    },
+
+    "required": ["axis", "events"]
+}

--- a/reference/controller/controller-gamepad-binding.json
+++ b/reference/controller/controller-gamepad-binding.json
@@ -1,0 +1,27 @@
+{
+    "id": "controller-gamepad-binding",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ControllerGamepadBindingConfig",
+    "description": "An instance of <a href=\"#controller-gamepad-binding\">a controller gamepad binding config.</a>",
+    "type": "object",
+
+    "properties": {
+        "buttons": {
+            "type": "array",
+            "title": "Buttons",
+            "description": "Array of <a href=\"#controller-gamepad-button-binding\">custom gamepad button binding.</a>.",
+            "items": {
+                "$ref": "controller-gamepad-button-binding"
+            }
+        },
+
+        "axes": {
+            "type": "array",
+            "title": "Axes",
+            "description": "Array of <a href=\"#controller-gamepad-axis-binding\">custom gamepad axis binding.</a>.",
+            "items": {
+                "$ref": "controller-gamepad-axis-binding"
+            }
+        }
+    }
+}

--- a/reference/controller/controller-gamepad-button-binding-events.json
+++ b/reference/controller/controller-gamepad-button-binding-events.json
@@ -1,0 +1,36 @@
+{
+    "id": "controller-gamepad-button-binding-events",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ControllerGamepadButtonBindingEventsConfig",
+    "description": "Available events to bind actions to for the <a href=\"#controller-gamepad\">controller gamepad.</a>",
+    "type": "object",
+
+    "properties": {
+        "onDown":{
+            "anyOf":[
+                {"type": "string"},
+                {"type": "array", "items": "string"}
+            ],
+            "title": "onDown",
+            "description": "The action or array of actions uid to trigger on button down event"
+        },
+
+        "onHold":{
+            "anyOf":[
+                {"type": "string"},
+                {"type": "array", "items": "string"}
+            ],
+            "title": "onHold",
+            "description": "The action or array of actions uid to trigger on button hold event"
+        },
+
+        "onUp":{
+            "anyOf":[
+                {"type": "string"},
+                {"type": "array", "items": "string"}
+            ],
+            "title": "onUp",
+            "description": "The action or array of actions uid to trigger on button up event"
+        }
+    }
+}

--- a/reference/controller/controller-gamepad-button-binding.json
+++ b/reference/controller/controller-gamepad-button-binding.json
@@ -1,0 +1,39 @@
+{
+    "id": "controller-gamepad-button-binding",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "ControllerGamepadButtonBindingConfig",
+    "description": "A custom <a href=\"#controller-gamepad-binding\">controller gamepad</a> button binding.",
+    "type": "object",
+
+    "properties": {
+        "name":{
+            "type": "string",
+            "title": "Name",
+            "description": "The name of this button binding"
+        },
+
+        "in":{
+            "anyOf":[
+                {"type": "number"},
+                {"type": "array", "items": "number"}
+            ],
+            "title": "In",
+            "description": "The button code or array of button codes that are associated to this button binding."
+        },
+
+        "out":{
+            "anyOf":[
+                {"type": "number"},
+                {"type": "array", "items": "number"}
+            ],
+            "title": "Out",
+            "description": "The button code or array of button codes that are associated to this button binding."
+        },
+
+        "events":{
+            "$ref": "controller-gamepad-button-binding-events"
+        }
+    },
+
+    "required": ["in", "events"]
+}

--- a/reference/controller/controller-gamepad.json
+++ b/reference/controller/controller-gamepad.json
@@ -1,7 +1,7 @@
 {
-    "id": "controller-keyboard",
+    "id": "controller-gamepad",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "ControllerKeyboardConfig",
+    "title": "ControllerGamepadConfig",
     "description": "An instance of <a href=\"#controller-gamepad\">a controller gamepad.</a>",
     "type": "object",
 
@@ -10,7 +10,7 @@
             "$ref": "controller-options-orientation"
         },
 
-        "zoom":{
+        "zoom": {
             "$ref": "controller-options-zoom"
         },
 
@@ -22,12 +22,7 @@
         },
 
         "bindings": {
-            "type": "array",
-            "title": "Bindings",
-            "description": "Array of <a href=\"#controller-keyboard-binding\">custom keyboard key bindings</a>.",
-            "items": {
-                "$ref": "controller-keyboard-binding"
-            }
+            "$ref": "controller-gamepad-binding"
         }
     }
 }

--- a/reference/controller/controller-instance.json
+++ b/reference/controller/controller-instance.json
@@ -17,7 +17,7 @@
             "type": "string",
             "enum": ["pointer"],
             "title": "Type",
-            "description": "Type of the controller to instanciate. Can either be :<ul><li>pointer</li><li>keyboard</li><li>gyroscope</li></ul>",
+            "description": "Type of the controller to instanciate. Can either be :<ul><li>pointer</li><li>keyboard</li><li>gyroscope</li><li>gamepad</li></ul>",
             "example": "pointer"
         },
 
@@ -31,7 +31,8 @@
         "options":{
             "anyOf": [
                 { "$ref": "controller-pointer" },
-                { "$ref": "controller-keyboard" }
+                { "$ref": "controller-keyboard" },
+                { "$ref": "controller-gamepad" }
             ]
         }
     },

--- a/reference/controller/controller-keyboard-binding.json
+++ b/reference/controller/controller-keyboard-binding.json
@@ -26,7 +26,7 @@
                 {"type": "number"},
                 {"type": "array", "items": "number"}
             ],
-            "title": "In",
+            "title": "Out",
             "description": "The key code or array of keycodes that are associated to this key binding. Corresponds to a <a href=\"https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode\">KeyboardEvent.keyCode</a>"
         },
 

--- a/src/camera/Camera.js
+++ b/src/camera/Camera.js
@@ -244,7 +244,7 @@ FORGE.Camera.DEFAULT_CONFIG = {
     {
         min: -Infinity,
         max: Infinity,
-        default: 0,
+        default: 0
     },
     pitch:
     {

--- a/src/controllers/ControllerGamepad.js
+++ b/src/controllers/ControllerGamepad.js
@@ -1,0 +1,413 @@
+/**
+ * A gamepad controller (type xbox or ps4 for example).
+ *
+ * @constructor FORGE.ControllerGamepad
+ * @param {FORGE.Viewer} viewer - viewer reference
+ * @param {ControllerInstanceConfig} config - the configuration of the controller
+ * @extends {FORGE.ControllerBase}
+ */
+FORGE.ControllerGamepad = function(viewer, config)
+{
+    /**
+     * A list of associated gamepad
+     * @name FORGE.ControllerGamepad#_gamepads
+     * @type {?Array<FORGE.Gamepad>}
+     * @private
+     */
+    this._gamepads = null;
+
+    /**
+     * Configuration
+     * @name FORGE.ControllerGamepad#_config
+     * @type {ControllerInstanceConfig}
+     * @private
+     */
+    this._config = config;
+
+    /**
+     * Orientation controller configuration.
+     * @name FORGE.ControllerGamepad#_orientation
+     * @type {ControllerOrientationConfig}
+     * @private
+     */
+    this._orientation;
+
+    /**
+     * Zoom controller configuration.
+     * @name FORGE.ControllerGamepad#_zoom
+     * @type {ControllerZoomConfig}
+     * @private
+     */
+    this._zoom;
+
+    /**
+     * Previous position vector.
+     * @name FORGE.ControllerGamepad#_positionStart
+     * @type {THREE.Vector2}
+     * @private
+     */
+    this._positionStart = null;
+
+    /**
+     * Previous position vector.
+     * @name FORGE.ControllerGamepad#_positionCurrent
+     * @type {THREE.Vector2}
+     * @private
+     */
+    this._positionCurrent = null;
+
+    /**
+     * Current velocity vector.
+     * @name FORGE.ControllerGamepad#_velocity
+     * @type {THREE.Vector2}
+     * @private
+     */
+    this._velocity = null;
+
+    /**
+     * Previous velocity vector.
+     * @name FORGE.ControllerGamepad#_inertia
+     * @type {THREE.Vector2}
+     * @private
+     */
+    this._inertia = null;
+
+    /**
+     * Array of all button bindings
+     * @name FORGE.ControllerGamepad#_buttonBindings
+     * @type {Array<FORGE.ButtonBinding>}
+     * @private
+     */
+    this._buttonBindings = null;
+
+    FORGE.ControllerBase.call(this, viewer, "ControllerGamepad");
+};
+
+FORGE.ControllerGamepad.prototype = Object.create(FORGE.ControllerBase.prototype);
+FORGE.ControllerGamepad.prototype.constructor = FORGE.ControllerGamepad;
+
+/**
+ * Default configuration
+ * @name {FORGE.ControllerGamepad.DEFAULT_OPTIONS}
+ * @type {ControllerKeyboardConfig}
+ */
+FORGE.ControllerGamepad.DEFAULT_OPTIONS = {
+    orientation:
+    {
+        hardness: 0.6, //Hardness factor impatcing controller response to some instant force.
+        damping: 0.15, //Damping factor controlling inertia.
+        velocityMax: 300,
+        invert: false
+    },
+
+    zoom:
+    {
+        hardness: 5,
+        invert: false
+    }
+};
+
+/**
+ * Boot sequence.
+ * @method FORGE.ControllerGamepad#_boot
+ * @private
+ */
+FORGE.ControllerGamepad.prototype._boot = function()
+{
+    FORGE.ControllerBase.prototype._boot.call(this);
+
+    this._type = FORGE.ControllerType.GAMEPAD;
+
+    this._gamepads = [];
+
+    this._buttonBindings = [];
+
+    this._inertia = new THREE.Vector2();
+    this._velocity = new THREE.Vector2();
+    this._positionStart = new THREE.Vector2();
+    this._positionCurrent = new THREE.Vector2();
+
+    this._parseConfig(this._config);
+
+    if (this._enabled === true)
+    {
+        this.enable();
+    }
+
+    this._viewer.gamepad.onGamepadConnected.add(this._onGamepadConnectedHandler, this);
+    this._viewer.gamepad.onGamepadDisconnected.add(this._onGamepadDisconnectedHandler, this);
+};
+
+/**
+ * Parse the configuration.
+ * @method FORGE.ControllerGamepad#_parseConfig
+ * @param {ControllerInstanceConfig} config - configuration object to parse.
+ */
+FORGE.ControllerGamepad.prototype._parseConfig = function(config)
+{
+    this._uid = config.uid;
+    this._register();
+
+    var options = config.options ||
+    {};
+
+    this._orientation = /** @type {ControllerOrientationConfig} */ (FORGE.Utils.extendMultipleObjects(FORGE.ControllerGamepad.DEFAULT_OPTIONS.orientation, options.orientation));
+    this._zoom = /** @type {ControllerZoomConfig} */ (FORGE.Utils.extendMultipleObjects(FORGE.ControllerGamepad.DEFAULT_OPTIONS.zoom, options.zoom));
+
+    this._enabled = (typeof config.enabled === "boolean") ? config.enabled : true;
+
+    if (options.default !== false)
+    {
+        this._addDefaultBindings();
+    }
+
+    if (Array.isArray(options.bindings) === true)
+    {
+        for (var i = 0, ii = options.bindings.length; i < ii; i++)
+        {
+            this._addBinding(options.bindings[i]);
+        }
+    }
+};
+
+/**
+ * Add the default bindings ot the controller gamepad : direction with left stick, zoom with LT and
+ * RT buttons (6 and 7 according to standard mapping).
+ * @method FORGE.ControllerGamepad#_addDefaultBindings
+ * @private
+ */
+FORGE.ControllerGamepad.prototype._addDefaultBindings = function()
+{
+    var bindingPlus = new FORGE.ButtonBinding(this._viewer,
+        6,
+        this._zoomDownHandler,
+        this._zoomUpHandler,
+        this._zoomHoldHandler,
+        7,
+        this,
+        "plus"
+    );
+    this._buttonBindings.push(bindingPlus);
+
+    var bindingMinus = new FORGE.ButtonBinding(this._viewer,
+        7,
+        this._zoomDownHandler,
+        this._zoomUpHandler,
+        this._zoomHoldHandler,
+        6,
+        this,
+        "minus"
+    );
+    this._buttonBindings.push(bindingMinus);
+};
+
+/**
+ * Add a gamepad binding config to this controller.
+ * @method FORGE.ControllerGamepad#_addBinding
+ * @param {ControllerKeyboardBindingConfig} binding - The binding config to add.
+ * @private
+ */
+FORGE.ControllerGamepad.prototype._addBinding = function(binding)
+{
+    var buttonsIn = binding.in;
+    var buttonsOut = binding.out;
+    var name = binding.name;
+    var events = binding.events;
+
+    if (FORGE.Utils.isTypeOf(buttonsIn, "number") === false && FORGE.Utils.isArrayOf(buttonsIn, "number") === false)
+    {
+        this.warn("Can't add custom gamepad binding, keys in are invalid!");
+        return;
+    }
+
+    if (typeof events !== "object" && events === null)
+    {
+        this.warn("Can't add custom gamepad binding, events are invalid!");
+        return;
+    }
+
+    var binding = new FORGE.ButtonBinding(this._viewer, buttonsIn, events.onDown, events.onUp, events.onHold, buttonsOut, this, name);
+
+    this._buttonBindings.push(binding);
+};
+
+/**
+ * Event handler for zoom (+ / -) down handler.
+ * @method FORGE.ControllerGamepad#_zoomDownHandler
+ * @param  {FORGE.ButtonBinding} binding - The binding associated to the event.
+ * @private
+ */
+FORGE.ControllerGamepad.prototype._zoomDownHandler = function(binding)
+{
+    if (this._viewer.controllers.enabled === false)
+    {
+        return;
+    }
+
+    this._active = true;
+
+    this._zoomProcessBinding(binding);
+
+    if (this._onControlStart !== null)
+    {
+        this._onControlStart.dispatch();
+    }
+
+    this._viewer.controllers.notifyControlStart(this);
+};
+
+/**
+ * Event handler for zoom (+ / -) hold handler.
+ * @method FORGE.ControllerGamepad#_zoomHoldHandler
+ * @param  {FORGE.ButtonBinding} binding - The binding associated to the event.
+ * @private
+ */
+FORGE.ControllerGamepad.prototype._zoomHoldHandler = function(binding)
+{
+    this._zoomProcessBinding(binding);
+};
+
+/**
+ * Event handler for zoom (+ / -) up handler.
+ * @method FORGE.ControllerGamepad#_zoomUpHandler
+ * @private
+ */
+FORGE.ControllerGamepad.prototype._zoomUpHandler = function()
+{
+    this._active = false;
+
+    if (this._onControlEnd !== null)
+    {
+        this._onControlEnd.dispatch();
+    }
+
+    this._viewer.controllers.notifyControlEnd(this);
+};
+
+/**
+ * Process a key binding related to zoom for down and hold zoom handlers.
+ * @method FORGE.ControllerGamepad#_zoomProcessBinding
+ * @param  {FORGE.ButtonBinding} binding - The key binding related to zoom
+ * @private
+ */
+FORGE.ControllerGamepad.prototype._zoomProcessBinding = function(binding)
+{
+    var invert = this._zoom.invert ? 1 : -1;
+    var delta = invert / this._zoom.hardness;
+
+    switch (binding.name)
+    {
+        case "minus":
+            delta *= 10;
+            break;
+
+        case "plus":
+            delta *= -10;
+            break;
+    }
+
+    this._camera.fov = this._camera.fov - delta;
+};
+
+/**
+ * Add a gamepad to this controller.
+ * @method FORGE.ControllerGamepad#addGamepad
+ * @param {FORGE.Gamepad} gamepad - the gamepad to add
+ */
+FORGE.ControllerGamepad.prototype._onGamepadConnectedHandler = function(gamepad)
+{
+    gamepad = gamepad.data;
+
+    if (this._gamepads.indexOf(gamepad) === -1)
+    {
+        this._gamepads.push(gamepad);
+    }
+
+    var binding;
+
+    for (var i = 0, ii = this._buttonBindings.length; i < ii; i++)
+    {
+        binding = this._buttonBindings[i];
+        gamepad.addBinding(binding);
+    }
+};
+
+/*
+ * Remove a gamepad to this controller.
+ * @method FORGE.ControllerGamepad#removeGamepad
+ * @param {string} name - the name of the gamepad to remove
+ */
+FORGE.ControllerGamepad.prototype._onGamepadDisconnectedHandler = function(name)
+{
+    name = name.data;
+
+    var index;
+
+    for (var i = 0, ii = this._gamepads.length; i < ii; i++)
+    {
+        if (this._gamepads[i].name === name)
+        {
+            index = i;
+            break;
+        }
+    }
+
+    if (index !== -1)
+    {
+        this._gamepads.splice(index, 1);
+    }
+};
+
+/**
+ * Enable controller
+ * @method FORGE.ControllerGamepad#enable
+ */
+FORGE.ControllerGamepad.prototype.enable = function()
+{
+    FORGE.ControllerBase.prototype.enable.call(this);
+
+    var binding;
+
+    for (var i = 0, ii = this._buttonBindings.length; i < ii; i++)
+    {
+        binding = this._buttonBindings[i];
+
+        for (var j = 0, jj = this._gamepads.length; j < jj; j++)
+        {
+            this._gamepads[j].addBinding(binding);
+        }
+    }
+};
+
+/**
+ * Disable controller
+ * @method FORGE.ControllerGamepad#disable
+ */
+FORGE.ControllerGamepad.prototype.disable = function()
+{
+    FORGE.ControllerBase.prototype.disable.call(this);
+
+    var binding;
+
+    for (var i = 0, ii = this._buttonBindings.length; i < ii; i++)
+    {
+        binding = this._buttonBindings[i];
+
+        for (var j = 0, jj = this._gamepads.length; j < jj; j++)
+        {
+            this._gamepads[j].removeBinding(binding);
+        }
+    }
+};
+
+/**
+ * Destroy routine
+ * @method FORGE.ControllerGamepad#destroy
+ */
+FORGE.ControllerGamepad.prototype.destroy = function()
+{
+    this._viewer.gamepad.onGamepadConnected.remove(this._onGamepadConnectedHandler, this);
+    this._viewer.gamepad.onGamepadDisconnected.remove(this._onGamepadDisconnectedHandler, this);
+
+    FORGE.ControllerBase.prototype.destroy.call(this);
+};

--- a/src/controllers/ControllerGamepad.js
+++ b/src/controllers/ControllerGamepad.js
@@ -254,9 +254,9 @@ FORGE.ControllerGamepad.prototype._addButtonBinding = function(binding)
         return;
     }
 
-    var binding = new FORGE.ButtonBinding(this._viewer, buttonsIn, events.onDown, events.onUp, events.onHold, buttonsOut, this, name);
+    var buttonBinding = new FORGE.ButtonBinding(this._viewer, buttonsIn, events.onDown, events.onUp, events.onHold, buttonsOut, this, name);
 
-    this._buttonBindings.push(binding);
+    this._buttonBindings.push(buttonBinding);
 };
 
 /**
@@ -267,13 +267,13 @@ FORGE.ControllerGamepad.prototype._addButtonBinding = function(binding)
  */
 FORGE.ControllerGamepad.prototype._addAxisBinding = function(binding)
 {
-    var axes = binding.axes;
+    var axis = binding.axis;
     var name = binding.name;
     var events = binding.events;
 
-    if (FORGE.Utils.isTypeOf(axes, "number") === false && FORGE.Utils.isArrayOf(axes, "number") === false)
+    if (FORGE.Utils.isTypeOf(axis, "number") === false && FORGE.Utils.isArrayOf(axis, "number") === false)
     {
-        this.warn("Can't add custom gamepad binding, axes in are invalid!");
+        this.warn("Can't add custom gamepad binding, axis in is invalid!");
         return;
     }
 
@@ -283,9 +283,9 @@ FORGE.ControllerGamepad.prototype._addAxisBinding = function(binding)
         return;
     }
 
-    var binding = new FORGE.AxisBinding(this._viewer, axes, events.move, this, name);
+    var axisBinding = new FORGE.AxisBinding(this._viewer, axis, events.onMove, this, name);
 
-    this._axisBindings.push(binding);
+    this._axisBindings.push(axisBinding);
 };
 
 /**
@@ -435,7 +435,7 @@ FORGE.ControllerGamepad.prototype._onGamepadConnectedHandler = function(gamepad)
     }
 };
 
-/*
+/**
  * Remove a gamepad to this controller.
  * @method FORGE.ControllerGamepad#removeGamepad
  * @param {string} name - the name of the gamepad to remove

--- a/src/controllers/ControllerGamepad.js
+++ b/src/controllers/ControllerGamepad.js
@@ -216,7 +216,7 @@ FORGE.ControllerGamepad.prototype._addDefaultBindings = function()
 
     var bindingYaw = new FORGE.AxisBinding(this._viewer,
         0,
-        this._yawMoveHandler,
+        this._yawChangeHandler,
         this,
         "yaw"
     );
@@ -224,7 +224,7 @@ FORGE.ControllerGamepad.prototype._addDefaultBindings = function()
 
     var bindingPitch = new FORGE.AxisBinding(this._viewer,
         1,
-        this._pitchMoveHandler,
+        this._pitchChangeHandler,
         this,
         "pitch"
     );
@@ -285,19 +285,19 @@ FORGE.ControllerGamepad.prototype._addAxisBinding = function(binding)
         return;
     }
 
-    var axisBinding = new FORGE.AxisBinding(this._viewer, axis, events.onMove, this, name);
+    var axisBinding = new FORGE.AxisBinding(this._viewer, axis, events.onChange, this, name);
 
     this._axisBindings.push(axisBinding);
 };
 
 /**
- * Event handler for yaw movement.
- * @method FORGE.ControllerGamepad#_yawMoveHandler
+ * Event handler for yaw changement.
+ * @method FORGE.ControllerGamepad#_yawChangeHandler
  * @param {FORGE.AxisBinding} binding - the reference to the binding
- * @param {number} value - the value of the move of the yaw
+ * @param {number} value - the value of the change of the yaw
  * @private
  */
-FORGE.ControllerGamepad.prototype._yawMoveHandler = function(binding, value)
+FORGE.ControllerGamepad.prototype._yawChangeHandler = function(binding, value)
 {
     // Check the delta, as the value isn't exactly 0 at rest
     if (Math.abs(value) < 0.1)
@@ -311,13 +311,13 @@ FORGE.ControllerGamepad.prototype._yawMoveHandler = function(binding, value)
 };
 
 /**
- * Event handler for pitch movement.
- * @method FORGE.ControllerGamepad#_pitchMoveHandler
+ * Event handler for pitch changement.
+ * @method FORGE.ControllerGamepad#_pitchChangeHandler
  * @param {FORGE.AxisBinding} binding - the reference to the binding
- * @param {number} value - the value of the move of the pitch
+ * @param {number} value - the value of the change of the pitch
  * @private
  */
-FORGE.ControllerGamepad.prototype._pitchMoveHandler = function(binding, value)
+FORGE.ControllerGamepad.prototype._pitchChangeHandler = function(binding, value)
 {
     // Check the delta, as the value isn't exactly 0 at rest
     if (Math.abs(value) < 0.1)
@@ -409,8 +409,8 @@ FORGE.ControllerGamepad.prototype._zoomProcessBinding = function(binding)
 };
 
 /**
- * Add a gamepad to this controller.
- * @method FORGE.ControllerGamepad#addGamepad
+ * When a gamepad is connected, add bindings to it.
+ * @method FORGE.ControllerGamepad#_onGamepadConnectedHandler
  * @param {FORGE.Gamepad} gamepad - the gamepad to add
  */
 FORGE.ControllerGamepad.prototype._onGamepadConnectedHandler = function(gamepad)
@@ -438,8 +438,8 @@ FORGE.ControllerGamepad.prototype._onGamepadConnectedHandler = function(gamepad)
 };
 
 /**
- * Remove a gamepad to this controller.
- * @method FORGE.ControllerGamepad#removeGamepad
+ * When a gamepad is disconnected, remove bindings to it.
+ * @method FORGE.ControllerGamepad#_onGamepadDisconnectedHandler
  * @param {string} name - the name of the gamepad to remove
  */
 FORGE.ControllerGamepad.prototype._onGamepadDisconnectedHandler = function(name)

--- a/src/controllers/ControllerKeyboard.js
+++ b/src/controllers/ControllerKeyboard.js
@@ -500,7 +500,7 @@ FORGE.ControllerKeyboard.prototype.update = function()
     {
         return;
     }
-    
+
     var invert = this._orientation.invert ? -1 : 1;
     this._camera.yaw += invert * dx;
     this._camera.pitch -= invert * dy;

--- a/src/controllers/ControllerManager.js
+++ b/src/controllers/ControllerManager.js
@@ -76,6 +76,11 @@ FORGE.ControllerManager.DEFAULT_CONFIG =
         {
             type: FORGE.ControllerType.GYROSCOPE,
             enabled: true
+        },
+
+        {
+            type: FORGE.ControllerType.GAMEPAD,
+            enabled: true
         }
     ]
 };
@@ -111,6 +116,10 @@ FORGE.ControllerManager.prototype._parseConfig = function(config)
 
                 case FORGE.ControllerType.GYROSCOPE:
                     controller = new FORGE.ControllerGyroscope(this._viewer, controllerConfig);
+                    break;
+
+                case FORGE.ControllerType.GAMEPAD:
+                    controller = new FORGE.ControllerGamepad(this._viewer, controllerConfig);
                     break;
 
                 default:

--- a/src/controllers/ControllerType.js
+++ b/src/controllers/ControllerType.js
@@ -32,3 +32,9 @@ FORGE.ControllerType.KEYBOARD = "keyboard";
  */
 FORGE.ControllerType.GYROSCOPE = "gyroscope";
 
+/**
+ * @name FORGE.ControllerType.GAMEPAD
+ * @type {string}
+ * @const
+ */
+FORGE.ControllerType.GAMEPAD = "gamepad";

--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -1325,6 +1325,21 @@ Object.defineProperty(FORGE.Viewer.prototype, "gyroscope",
 });
 
 /**
+ * Get the viewer gamepad interface.
+ * @name FORGE.Viewer#gamepad
+ * @type {FORGE.GamepadsManager}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Viewer.prototype, "gamepad",
+{
+    /** @this {FORGE.Viewer} */
+    get: function()
+    {
+        return this._gamepad;
+    }
+});
+
+/**
  * Get and set the viewer width.
  * @name FORGE.Viewer#width
  * @type {number}

--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -207,6 +207,14 @@ FORGE.Viewer = function(parent, config, callbacks)
     this._gyroscope = null;
 
     /**
+     * Gamepads manager.
+     * @name FORGE.Viewer#_gamepad
+     * @type {FORGE.GamepadsManager}
+     * @private
+     */
+    this._gamepad = null;
+
+    /**
      * Plugins interface reference.
      * @name FORGE.Viewer#_plugins
      * @type {FORGE.PluginManager}
@@ -365,6 +373,7 @@ FORGE.Viewer.prototype._boot = function(callback)
 
     this._keyboard = new FORGE.Keyboard(this);
     this._gyroscope = new FORGE.Gyroscope(this);
+    this._gamepad = new FORGE.GamepadsManager(this);
     this._cache = new FORGE.Cache(this);
     this._load = new FORGE.Loader(this);
     this._tween = new FORGE.TweenManager(this);
@@ -576,6 +585,7 @@ FORGE.Viewer.prototype._updateLogic = function()
 {
     this._display.update();
     this._keyboard.update();
+    this._gamepad.update();
     this._audio.update();
     this._plugins.update();
     this._tween.update();
@@ -726,6 +736,9 @@ FORGE.Viewer.prototype.destroy = function()
 
     this._gyroscope.destroy();
     this._gyroscope = null;
+
+    this._gamepad.destroy();
+    this._gamepad = null;
 
     this._hotspots.destroy();
     this._hotspots = null;

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -79,6 +79,9 @@ FORGE.Gamepad.prototype.constructor = FORGE.Gamepad;
  */
 FORGE.Gamepad.prototype._boot = function()
 {
+    this._uid = this._gamepad.id + "-" + this._gamepad.index;
+    this._register();
+
     this._buttonBindings = [];
     this._axisBindings = [];
 
@@ -440,5 +443,20 @@ Object.defineProperty(FORGE.Gamepad.prototype, "enabled",
     set: function(value)
     {
         this._enabled = Boolean(value);
+    }
+});
+
+/**
+ * Gets the raw data of the gamepad (the Gamepad object, not the FORGE one).
+ * @name FORGE.Gamepad#gamepad
+ * @type {Gamepad}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Gamepad.prototype, "gamepad",
+{
+    /** @this {FORGE.Gamepad} */
+    get: function()
+    {
+        return this._gamepad;
     }
 });

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -1,0 +1,380 @@
+/**
+ * Gamepads manager that handles gamepads
+ *
+ * @constructor FORGE.Gamepad
+ * @param {FORGE.Viewer} viewer - {@link FORGE.Viewer} reference.
+ * @param {Gamepad} ref - the reference to the Gamepad object.
+ * @extends {FORGE.BaseObject}
+ */
+FORGE.Gamepad = function(viewer, ref)
+{
+    /**
+     * The viewer reference.
+     * @name FORGE.Gamepad#_viewer
+     * @type {FORGE.Viewer}
+     * @private
+     */
+    this._viewer = viewer;
+
+    /**
+     * The reference to the Gamepad object
+     * @name FORGE.Gamepad#_gamepad
+     * @type {Gamepad}
+     * @private
+     */
+    this._gamepad = ref;
+
+    /**
+     * The timestamp saved the last time the gamepad was updated.
+     * @name FORGE.Gamepad#_previousTimestamp
+     * @type {number}
+     * @private
+     */
+    this._previousTimestamp = 0;
+
+    /**
+     * Is the gamepad enabled?
+     * @name FORGE.Gamepad#_enabled
+     * @type {boolean}
+     * @private
+     */
+    this._enabled = true;
+
+    /**
+     * The array that handles the {@link FORGE.KeyBinding} objects.
+     * @name FORGE.Gamepad#_buttonBindings
+     * @type {?Array<FORGE.ButtonBinding>}
+     * @private
+     */
+    this._buttonBindings = null;
+
+    /**
+     * The array that handles the {@link FORGE.AxesBinding} objects.
+     * @name FORGE.Gamepad#_axesBindings
+     * @type {?Array<FORGE.AxisBinding>}
+     * @private
+     */
+    this._axesBindings = null;
+
+    /**
+     * The array that handles the button codes that are considered as pressed.
+     * @name FORGE.Gamepad#_buttonPressed
+     * @type {?Array<number>}
+     * @private
+     */
+    this._buttonPressed = null;
+
+    FORGE.BaseObject.call(this, "Gamepad");
+
+    this._boot();
+};
+
+FORGE.Gamepad.prototype = Object.create(FORGE.BaseObject.prototype);
+FORGE.Gamepad.prototype.constructor = FORGE.Gamepad;
+
+/**
+ * Boot sequence.
+ * @method FORGE.Gamepad#_boot
+ * @private
+ */
+FORGE.Gamepad.prototype._boot = function()
+{
+    this._buttonBindings = [];
+    this._axesBindings = [];
+
+    this._buttonPressed = [];
+};
+
+/**
+ * Get the index of a KeyBinding.
+ * @method FORGE.Gamepad#_indexOfBinding
+ * @param  {FORGE.KeyBinding|number} value - The ButtonBinding or a button code (number).
+ * @return {number} Returns the searched index if found, if not, returns -1.
+ * @private
+ */
+FORGE.Gamepad.prototype._indexOfBinding = function(value)
+{
+    if (this._buttonBindings === null || this._buttonBindings.length === 0)
+    {
+        return -1;
+    }
+
+    if (typeof value === "object" && value.type === "KeyBinding")
+    {
+        return this._buttonBindings.indexOf(value);
+    }
+
+    if (typeof value === "number")
+    {
+        for (var i = 0, ii = this._buttonBindings.length; i < ii; i++)
+        {
+            if (this._buttonBindings[i].hasButtonIn(value) === true)
+            {
+                return i;
+            }
+        }
+    }
+
+    return -1;
+};
+
+/**
+ * Process all buttons in the gamepad.
+ * @method FORGE.Gamepad#_processButtons
+ * @param {Array<GamepadButton>} buttons - the array of GamepadButton
+ * @private
+ */
+FORGE.Gamepad.prototype._processButtons = function(buttons)
+{
+    var button, index, binding;
+
+    // First process buttons
+    for (var i = 0, ii = buttons.length; i < ii; i++)
+    {
+        button = buttons[i];
+        index = this._buttonPressed.indexOf(i);
+
+        if (button.pressed === true && index === -1)
+        {
+            this.log("button pressed " + i);
+            this._buttonPressed.push(i);
+
+            this._applyButton(i, button.value, true);
+        }
+        else if (button.pressed === false && index !== -1)
+        {
+            this.log("button released " + i);
+            this._buttonPressed.splice(index, 1);
+
+            this._applyButton(i, button.value, false);
+        }
+    }
+
+    // Then process bindings for hold actions
+    for (i = 0, ii = buttonBindings.length; i < ii; i++)
+    {
+        binding = buttonBindings[i];
+
+        if (binding.pressed === true)
+        {
+            if (binding.hasToWaitToHold === true && binding.downComplete === false)
+            {
+                continue;
+            }
+
+            binding.hold();
+        }
+    }
+};
+
+/**
+ * Get an array of bindings associated to the button.
+ * @method FORGE.Gamepad#_getButtonBindings
+ * @param {number} index - the index of the button
+ * @return {Array<FORGE.KeyBinding>} an array of bindings
+ * */
+FORGE.Gamepad.prototype._getButtonBindings = function(index)
+{
+    var bindings = [];
+
+    for (var i = 0, ii = this._buttonBindings.length; i < ii; i++)
+    {
+        if (this._buttonBindings[i].hasButtonIn(index) === true)
+        {
+            bindings.push(this._buttonBindings[i]);
+        }
+    }
+
+    return bindings;
+};
+
+/**
+ * Apply the callbacks associated to the button.
+ * @method FORGE.Gamepad#_applyButton
+ * @param {number} index - the index of the button
+ * @param {number} value - the value of the button
+ * @param {boolean} pressed - is the button pressed ?
+ * @private
+ */
+FORGE.Gamepad.prototype._applyButton = function(index, value, pressed)
+{
+    var binding, bindings = this._getButtonBindings(index);
+
+    for (var i = 0, ii = bindings.length; i < ii; i++)
+    {
+        binding = bindings[i];
+
+        // Button down
+        if (pressed === true && binding.pressed === false)
+        {
+            binding.down(value);
+        }
+        // Button up
+        else if (pressed === false && binding.pressed === true)
+        {
+            binding.up(value);
+        }
+    }
+};
+
+/**
+ * Process all buttons in the gamepad.
+ * @method FORGE.Gamepad#_processAxes
+ * @param {Array<number>} axes - the value of each axis
+ * @private
+ */
+FORGE.Gamepad.prototype._processAxes = function(axes)
+{
+};
+
+/**
+ * Process the pose of the gamepad.
+ * @method FORGE.Gamepad#_processPose
+ * @param {GamepadPose} pose - the pose object
+ * @private
+ */
+FORGE.Gamepad.prototype._processPose = function(pose)
+{
+};
+
+/**
+ * Update routine.
+ * @method FORGE.Gamepad#update
+ */
+FORGE.Gamepad.prototype.update = function()
+{
+    if (this._enabled === true && this._gamepad.timestamp > this._previousTimestamp)
+    {
+        this._previousTimestamp = this._gamepad.timestamp;
+
+        // Process buttons
+        if (typeof this._gamepad.buttons !== "undefined")
+        {
+            this._processButtons(this._gamepad.buttons);
+        }
+
+        // Process axis
+        if (typeof this._gamepad.axes !== "undefined")
+        {
+            this._processAxes(this._gamepad.axes);
+        }
+
+        // Process pose
+        if (typeof this._gamepad.pose !== "undefined")
+        {
+            this._processPose(this._gamepad.pose);
+        }
+    }
+};
+
+/**
+ * Add a ButtonBinding to the Gamepad's buttonBindings array.
+ * @method FORGE.Gamepad#addBinding
+ * @param {FORGE.KeyBinding} buttonBinding - The FORGE.KeyBinding you want to add.
+ * @return {boolean} Returns true if it's correctly added, false if it's already in or if wrong type.
+ */
+FORGE.Gamepad.prototype.addBinding = function(buttonBinding)
+{
+    if (typeof buttonBinding !== "object" && buttonBinding.type !== "KeyBinding")
+    {
+        return false;
+    }
+
+    var index = this._indexOfBinding(buttonBinding);
+
+    if (index === -1)
+    {
+        this._buttonBindings.push(buttonBinding);
+        return true;
+    }
+    else
+    {
+        this.warn("Trying to add a duplicate button binding on the gamepad !");
+    }
+
+    return false;
+};
+
+/**
+ * Remove a {@link FORGE.KeyBinding} from the {@link FORGE.Gamepad} object.
+ * @method FORGE.Gamepad#removeBinding
+ * @param  {FORGE.KeyBinding|number} buttonBinding - A {@link FORGE.KeyBinding} or a number that represent a button code.
+ * @return {boolean} Returns true if it's removed, false if not found.
+ */
+FORGE.Gamepad.prototype.removeBinding = function(buttonBinding)
+{
+    var index = this._indexOfBinding(buttonBinding);
+
+    if (index !== -1)
+    {
+        this._buttonBindings[index].destroy();
+        this._buttonBindings.splice(index, 1);
+        return true;
+    }
+
+    return false;
+};
+
+/**
+ * Destroy sequence.
+ * @method FORGE.Gamepad#destroy
+ */
+FORGE.Gamepad.prototype.destroy = function()
+{
+    this._viewer = null;
+
+    var buttonBinding;
+
+    while (this._buttonBindings !== null && this._buttonBindings.length > 0)
+    {
+        buttonBinding = this._buttonBindings.pop();
+        buttonBinding.destroy();
+    }
+    this._buttonBindings = null;
+
+    var axisBinding;
+
+    while (this._axesBindings !== null && this._axesBindings.length > 0)
+    {
+        axisBinding = this._axesBindings.pop();
+        axisBinding.destroy();
+    }
+    this._axesBindings = null;
+
+    FORGE.BaseObject.prototype.destroy.call(this);
+};
+
+/**
+ * Gets the name of the gamepad.
+ * @name FORGE.Gamepad#name
+ * @type {string}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Gamepad.prototype, "name",
+{
+    /** @this {FORGE.Gamepad} */
+    get: function()
+    {
+        return this._gamepad.id;
+    }
+});
+
+/**
+ * Gets or sets the enabled status of the gamepad.
+ * @name FORGE.Gamepad#enabled
+ * @type {boolean}
+ */
+Object.defineProperty(FORGE.Gamepad.prototype, "enabled",
+{
+    /** @this {FORGE.Gamepad} */
+    get: function()
+    {
+        return this._enabled;
+    },
+
+    /** @this {FORGE.Gamepad} */
+    set: function(value)
+    {
+        this._enabled = Boolean(value);
+    }
+});

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -103,11 +103,11 @@ FORGE.Gamepad.prototype._indexOfBinding = function(value)
     {
         if (value.type === "ButtonBinding")
         {
-            return this._buttonBindings.indexOf(value);
+            return this._buttonBindings.indexOf(/** @type {FORGE.ButtonBinding} */ (value));
         }
         else if (value.type === "AxisBinding")
         {
-            return this._axisBindings.indexOf(value);
+            return this._axisBindings.indexOf(/** @type {FORGE.AxisBinding} */ (value));
         }
     }
 
@@ -173,6 +173,7 @@ FORGE.Gamepad.prototype._applyHoldButtons = function()
         }
     }
 };
+
 
 /**
  * Get an array of bindings associated to the button.
@@ -332,12 +333,12 @@ FORGE.Gamepad.prototype.addBinding = function(binding)
     {
         if (binding.type === "ButtonBinding")
         {
-            this._buttonBindings.push(binding);
+            this._buttonBindings.push(/** @type {FORGE.ButtonBinding} */ (binding));
             return true;
         }
         else if (binding.type === "AxisBinding")
         {
-            this._axisBindings.push(binding);
+            this._axisBindings.push(/** @type {FORGE.AxisBinding} */ (binding));
             return true;
         }
     }

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -41,7 +41,7 @@ FORGE.Gamepad = function(viewer, ref)
     this._enabled = true;
 
     /**
-     * The array that handles the {@link FORGE.KeyBinding} objects.
+     * The array that handles the {@link FORGE.ButtonBinding} objects.
      * @name FORGE.Gamepad#_buttonBindings
      * @type {?Array<FORGE.ButtonBinding>}
      * @private
@@ -86,9 +86,9 @@ FORGE.Gamepad.prototype._boot = function()
 };
 
 /**
- * Get the index of a KeyBinding.
+ * Get the index of a ButtonBinding.
  * @method FORGE.Gamepad#_indexOfBinding
- * @param  {FORGE.KeyBinding|number} value - The ButtonBinding or a button code (number).
+ * @param  {FORGE.ButtonBinding|number} value - The ButtonBinding or a button code (number).
  * @return {number} Returns the searched index if found, if not, returns -1.
  * @private
  */
@@ -99,7 +99,7 @@ FORGE.Gamepad.prototype._indexOfBinding = function(value)
         return -1;
     }
 
-    if (typeof value === "object" && value.type === "KeyBinding")
+    if (typeof value === "object" && value.type === "ButtonBinding")
     {
         return this._buttonBindings.indexOf(value);
     }
@@ -151,9 +151,9 @@ FORGE.Gamepad.prototype._processButtons = function(buttons)
     }
 
     // Then process bindings for hold actions
-    for (i = 0, ii = buttonBindings.length; i < ii; i++)
+    for (i = 0, ii = this._buttonBindings.length; i < ii; i++)
     {
-        binding = buttonBindings[i];
+        binding = this._buttonBindings[i];
 
         if (binding.pressed === true)
         {
@@ -161,6 +161,8 @@ FORGE.Gamepad.prototype._processButtons = function(buttons)
             {
                 continue;
             }
+
+            this.log("button hold " + i);
 
             binding.hold();
         }
@@ -171,7 +173,7 @@ FORGE.Gamepad.prototype._processButtons = function(buttons)
  * Get an array of bindings associated to the button.
  * @method FORGE.Gamepad#_getButtonBindings
  * @param {number} index - the index of the button
- * @return {Array<FORGE.KeyBinding>} an array of bindings
+ * @return {Array<FORGE.ButtonBinding>} an array of bindings
  * */
 FORGE.Gamepad.prototype._getButtonBindings = function(index)
 {
@@ -270,12 +272,12 @@ FORGE.Gamepad.prototype.update = function()
 /**
  * Add a ButtonBinding to the Gamepad's buttonBindings array.
  * @method FORGE.Gamepad#addBinding
- * @param {FORGE.KeyBinding} buttonBinding - The FORGE.KeyBinding you want to add.
+ * @param {FORGE.ButtonBinding} buttonBinding - The FORGE.ButtonBinding you want to add.
  * @return {boolean} Returns true if it's correctly added, false if it's already in or if wrong type.
  */
 FORGE.Gamepad.prototype.addBinding = function(buttonBinding)
 {
-    if (typeof buttonBinding !== "object" && buttonBinding.type !== "KeyBinding")
+    if (typeof buttonBinding !== "object" && buttonBinding.type !== "ButtonBinding")
     {
         return false;
     }
@@ -296,9 +298,9 @@ FORGE.Gamepad.prototype.addBinding = function(buttonBinding)
 };
 
 /**
- * Remove a {@link FORGE.KeyBinding} from the {@link FORGE.Gamepad} object.
+ * Remove a {@link FORGE.ButtonBinding} from the {@link FORGE.Gamepad} object.
  * @method FORGE.Gamepad#removeBinding
- * @param  {FORGE.KeyBinding|number} buttonBinding - A {@link FORGE.KeyBinding} or a number that represent a button code.
+ * @param  {FORGE.ButtonBinding|number} buttonBinding - A {@link FORGE.ButtonBinding} or a number that represent a button code.
  * @return {boolean} Returns true if it's removed, false if not found.
  */
 FORGE.Gamepad.prototype.removeBinding = function(buttonBinding)
@@ -355,7 +357,7 @@ Object.defineProperty(FORGE.Gamepad.prototype, "name",
     /** @this {FORGE.Gamepad} */
     get: function()
     {
-        return this._gamepad.id;
+        return this._gamepad.id + "-" + this._gamepad.index;
     }
 });
 

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -477,7 +477,6 @@ Object.defineProperty(FORGE.Gamepad.prototype, "enabled",
  * Gets the raw data of the gamepad (the Gamepad object, not the FORGE one).
  * @name FORGE.Gamepad#gamepad
  * @type {Gamepad}
- * @readonly
  */
 Object.defineProperty(FORGE.Gamepad.prototype, "gamepad",
 {
@@ -485,5 +484,14 @@ Object.defineProperty(FORGE.Gamepad.prototype, "gamepad",
     get: function()
     {
         return this._gamepad;
+    },
+
+    /** @this {FORGE.Gamepad} */
+    set: function(value)
+    {
+        if (value !== null)
+        {
+            this._gamepad = value;
+        }
     }
 });

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -266,19 +266,9 @@ FORGE.Gamepad.prototype._processAxes = function(axes)
 
         for (var j = 0, jj = bindings.length; j < jj; j++)
         {
-            bindings[j].move(axes[i]);
+            bindings[j].change(axes[i]);
         }
     }
-};
-
-/**
- * Process the pose of the gamepad.
- * @method FORGE.Gamepad#_processPose
- * @param {GamepadPose} pose - the pose object
- * @private
- */
-FORGE.Gamepad.prototype._processPose = function(pose)
-{
 };
 
 /**
@@ -303,12 +293,6 @@ FORGE.Gamepad.prototype.update = function()
             if (typeof this._gamepad.axes !== "undefined")
             {
                 this._processAxes(this._gamepad.axes);
-            }
-
-            // Process pose
-            if (typeof this._gamepad.pose !== "undefined")
-            {
-                this._processPose(this._gamepad.pose);
             }
         }
 

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -427,6 +427,51 @@ Object.defineProperty(FORGE.Gamepad.prototype, "name",
 });
 
 /**
+ * Gets the mapping of the gamepad.
+ * @name FORGE.Gamepad#mapping
+ * @type {string}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Gamepad.prototype, "mapping",
+{
+    /** @this {FORGE.Gamepad} */
+    get: function()
+    {
+        return this._gamepad.mapping;
+    }
+});
+
+/**
+ * Gets the hand of the gamepad if any.
+ * @name FORGE.Gamepad#hand
+ * @type {string}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Gamepad.prototype, "hand",
+{
+    /** @this {FORGE.Gamepad} */
+    get: function()
+    {
+        return this._gamepad.hand;
+    }
+});
+
+/**
+ * Gets the position of the gamepad, relative to the camera.
+ * @name FORGE.Gamepad#position
+ * @type {GamepadPose}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Gamepad.prototype, "position",
+{
+    /** @this {FORGE.Gamepad} */
+    get: function()
+    {
+        return this._gamepad.pose;
+    }
+});
+
+/**
  * Gets or sets the enabled status of the gamepad.
  * @name FORGE.Gamepad#enabled
  * @type {boolean}

--- a/src/input/Gamepad.js
+++ b/src/input/Gamepad.js
@@ -170,8 +170,6 @@ FORGE.Gamepad.prototype._applyHoldButtons = function()
                 continue;
             }
 
-            this.log("button hold " + i);
-
             binding.hold();
         }
     }

--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -68,7 +68,7 @@ FORGE.GamepadsManager.prototype._isConnected = function(gamepad)
 {
     for (var i = 0, ii = this._gamepads.length; i < ii; i++)
     {
-        if (this._gamepads[i].name === gamepad.id)
+        if (this._gamepads[i].name === (gamepad.id + "-" + gamepad.index))
         {
             return true;
         }
@@ -93,7 +93,7 @@ FORGE.GamepadsManager.prototype._connect = function(pad)
 
     if (this._onGamepadConnected !== null)
     {
-        this._onGamepadConnected.dispatch();
+        this._onGamepadConnected.dispatch(gamepad);
     }
 };
 
@@ -105,12 +105,14 @@ FORGE.GamepadsManager.prototype._connect = function(pad)
  */
 FORGE.GamepadsManager.prototype._disconnect = function(index)
 {
+    var name = this._gamepads[index].name;
+
     this._gamepads[index].destroy();
     this._gamepads[index] = null;
 
     if (this._onGamepadDisconnected !== null)
     {
-        this._onGamepadDisconnected.dispatch();
+        this._onGamepadDisconnected.dispatch(name);
     }
 };
 

--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -213,3 +213,18 @@ Object.defineProperty(FORGE.GamepadsManager.prototype, "onGamepadDisconnected",
         return this._onGamepadDisconnected;
     }
 });
+
+/**
+ * Get a list of all connected gamepads.
+ * @name FORGE.GamepadsManager#all
+ * @type {Array<FORGE.Gamepad>}
+ * @readonly
+ */
+Object.defineProperty(FORGE.GamepadsManager.prototype, "all",
+{
+    /** @this {FORGE.GamepadsManager} */
+    get: function()
+    {
+        return this._gamepads || [];
+    }
+});

--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -187,7 +187,7 @@ Object.defineProperty(FORGE.GamepadsManager.prototype, "onGamepadConnected",
     {
         if (this._onGamepadConnected === null)
         {
-            this._onGamepadConnected = new FORGE.EventDispatcher();
+            this._onGamepadConnected = new FORGE.EventDispatcher(this);
         }
 
         return this._onGamepadConnected;
@@ -207,7 +207,7 @@ Object.defineProperty(FORGE.GamepadsManager.prototype, "onGamepadDisconnected",
     {
         if (this._onGamepadDisconnected === null)
         {
-            this._onGamepadDisconnected = new FORGE.EventDispatcher();
+            this._onGamepadDisconnected = new FORGE.EventDispatcher(this);
         }
 
         return this._onGamepadDisconnected;

--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -1,0 +1,213 @@
+/**
+ * Gamepads manager that handles gamepads
+ *
+ * @constructor FORGE.GamepadsManager
+ * @param {FORGE.Viewer} viewer {@link FORGE.Viewer} reference.
+ * @extends {FORGE.BaseObject}
+ */
+FORGE.GamepadsManager = function(viewer)
+{
+    /**
+     * The viewer reference.
+     * @name FORGE.GamepadsManager#_viewer
+     * @type {FORGE.Viewer}
+     * @private
+     */
+    this._viewer = viewer;
+
+    /**
+     * The list of associated gamepads
+     * @name FORGE.GamepadsManager#_gamepads
+     * @type {?Array<FORGE.Gamepad>}
+     * @private
+     */
+    this._gamepads = null;
+
+    /**
+     * On gamepad connected event dispatcher.
+     * @name FORGE.GamepadsManager#_onGamepadConnected
+     * @type {?FORGE.EventDispatcher}
+     * @private
+     */
+    this._onGamepadConnected = null;
+
+    /**
+     * On gamepad disconnected event dispatcher.
+     * @name FORGE.GamepadsManager#_onGamepadDisconnected
+     * @type {?FORGE.EventDispatcher}
+     * @private
+     */
+    this._onGamepadDisconnected = null;
+
+    FORGE.BaseObject.call(this, "GamepadsManager");
+
+    this._boot();
+};
+
+FORGE.GamepadsManager.prototype = Object.create(FORGE.BaseObject.prototype);
+FORGE.GamepadsManager.prototype.constructor = FORGE.GamepadsManager;
+
+/**
+ * Boot sequence.
+ * @method FORGE.GamepadsManager#_boot
+ * @private
+ */
+FORGE.GamepadsManager.prototype._boot = function()
+{
+    this._gamepads = [];
+};
+
+/**
+ * Check if a gamepad (of type Gamepad) is connected.
+ * @method FORGE.GamepadsManager#_isConnected
+ * @param {Gamepad} gamepad - the gamepad to check
+ * @return {boolean} is the gamepad present ?
+ * @private
+ */
+FORGE.GamepadsManager.prototype._isConnected = function(gamepad)
+{
+    for (var i = 0, ii = this._gamepads.length; i < ii; i++)
+    {
+        if (this._gamepads[i].name === gamepad.id)
+        {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+/**
+ * Connect a gamepad (of type Gamepad).
+ * @method FORGE.GamepadsManager#_connect
+ * @param {Gamepad} pad - the gamepad to connect
+ * @private
+ */
+FORGE.GamepadsManager.prototype._connect = function(pad)
+{
+    var gamepad = new FORGE.Gamepad(this._viewer, pad);
+
+    this._gamepads[pad.index] = gamepad;
+
+    // TODO: add a haptic feedback if available
+
+    if (this._onGamepadConnected !== null)
+    {
+        this._onGamepadConnected.dispatch();
+    }
+};
+
+/**
+ * Disconnect a gamepad (of type FORGE.Gamepad).
+ * @method FORGE.GamepadsManager#_disconnect
+ * @param {number} index - the index of the gamepad to disconnect
+ * @private
+ */
+FORGE.GamepadsManager.prototype._disconnect = function(index)
+{
+    this._gamepads[index].destroy();
+    this._gamepads[index] = null;
+
+    if (this._onGamepadDisconnected !== null)
+    {
+        this._onGamepadDisconnected.dispatch();
+    }
+};
+
+/**
+ * Update routine: check each time if a new gamepad is connected, and update any gamepad currently
+ * connected in this manager.
+ * @method FORGE.GamepadsManager#update
+ */
+FORGE.GamepadsManager.prototype.update = function()
+{
+    var gamepad, gamepads = navigator.getGamepads();
+
+    for (var i = 0, ii = gamepads.length; i < ii; i++)
+    {
+        gamepad = gamepads[i];
+
+        if (gamepad !== null)
+        {
+            if (this._isConnected(gamepad) === false)
+            {
+                this._connect(gamepad);
+            }
+
+            this._gamepads[i].update();
+        }
+        else if (gamepad === null && typeof this._gamepads[i] !== "undefined")
+        {
+            this._disconnect(i);
+        }
+    }
+};
+
+/**
+ * Destroy sequence.
+ * @method FORGE.GamepadsManager#destroy
+ */
+FORGE.GamepadsManager.prototype.destroy = function()
+{
+    this._viewer = null;
+
+    for (var i = 0, ii = this._gamepads.length; i < ii; i++)
+    {
+        this._disconnect(i);
+    }
+    this._gamepads = null;
+
+    if (this._onGamepadConnected !== null)
+    {
+        this._onGamepadConnected.destroy();
+        this._onGamepadConnected = null;
+    }
+
+    if (this._onGamepadDisconnected !== null)
+    {
+        this._onGamepadDisconnected.destroy();
+        this._onGamepadDisconnected = null;
+    }
+
+    FORGE.BaseObject.prototype.destroy.call(this);
+};
+
+/**
+ * On gamepad connected event dispatcher.
+ * @name FORGE.GamepadsManager#onGamepadConnected
+ * @type {?FORGE.EventDispatcher}
+ * @readonly
+ */
+Object.defineProperty(FORGE.GamepadsManager.prototype, "onGamepadConnected",
+{
+    /** @this {FORGE.GamepadsManager} */
+    get: function()
+    {
+        if (this._onGamepadConnected === null)
+        {
+            this._onGamepadConnected = new FORGE.EventDispatcher();
+        }
+
+        return this._onGamepadConnected;
+    }
+});
+
+/**
+ * On gamepad disconnected event dispatcher.
+ * @name FORGE.GamepadsManager#onGamepadDisconnected
+ * @type {?FORGE.EventDispatcher}
+ * @readonly
+ */
+Object.defineProperty(FORGE.GamepadsManager.prototype, "onGamepadDisconnected",
+{
+    /** @this {FORGE.GamepadsManager} */
+    get: function()
+    {
+        if (this._onGamepadDisconnected === null)
+        {
+            this._onGamepadDisconnected = new FORGE.EventDispatcher();
+        }
+
+        return this._onGamepadDisconnected;
+    }
+});

--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -54,7 +54,7 @@ FORGE.GamepadsManager.prototype.constructor = FORGE.GamepadsManager;
  */
 FORGE.GamepadsManager.prototype._boot = function()
 {
-    if (FORGE.Device.ie === false)
+    if (FORGE.Device.ie === true)
     {
         return;
     }
@@ -139,6 +139,14 @@ FORGE.GamepadsManager.prototype.update = function()
             if (this._isConnected(gamepad) === false)
             {
                 this._connect(gamepad);
+            }
+            // curious behavior in edge, the pad isn't kept as a reference
+            // so it isn't updated: the solution for now is to refresh the
+            // gamepad each time
+            else if (FORGE.Device.edge === true)
+            {
+                var pad = this._gamepads[gamepad.index];
+                pad.gamepad = gamepad;
             }
 
             this._gamepads[i].update();

--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -129,7 +129,7 @@ FORGE.GamepadsManager.prototype.update = function()
     {
         gamepad = gamepads[i];
 
-        if (gamepad !== null)
+        if (typeof gamepad !== "undefined" && gamepad !== null)
         {
             if (this._isConnected(gamepad) === false)
             {

--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -54,6 +54,11 @@ FORGE.GamepadsManager.prototype.constructor = FORGE.GamepadsManager;
  */
 FORGE.GamepadsManager.prototype._boot = function()
 {
+    if (FORGE.Device.ie === false)
+    {
+        return;
+    }
+
     this._gamepads = [];
 };
 

--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -319,7 +319,7 @@ FORGE.Keyboard.prototype.update = function()
         {
             if(keyBinding.hasToWaitToHold === true && keyBinding.downComplete === false)
             {
-                return;
+                continue;
             }
 
             keyBinding.hold();

--- a/src/input/binding/AxisBinding.js
+++ b/src/input/binding/AxisBinding.js
@@ -1,0 +1,115 @@
+/**
+ * Axis binding object that handles axis event for a list of axes.
+ * To use an axis binding, you have to add ti to a {@link FORGE.Gamepad}.
+ *
+ * @constructor FORGE.AxisBinding
+ * @param {FORGE.Viewer} viewer - the viewer reference
+ * @param {number} axis - the axis code associated to this binding
+ * @param {?(Function|string|Array<string>)} move - the callback function that will be called on an axis movement
+ * @param {Object=} context - the context in which you want the callbacks to be executed
+ * @param {string=} name - the name of the binding
+ * @extends {FORGE.BaseBinding}
+ */
+FORGE.AxisBinding = function(viewer, axis, move, context, name)
+{
+    /**
+     * The axis code associated to this AxisBinding
+     * @name FORGE.AxisBinding#_axis
+     * @type {number}
+     * @private
+     */
+    this._axis = axis;
+
+    /**
+     * The callback function that will be called on an axis movement
+     * @name FORGE.AxisBinding#_move
+     * @type {?(Function|string|Array<string>)}
+     * @private
+     */
+    this._move = move || null;
+
+    /**
+     * Action event dispatcher for move action
+     * @name FORGE.AxisBinding#_moveActionEventDispatcher
+     * @type {?FORGE.ActionEventDispatcher}
+     * @private
+     */
+    this._moveActionEventDispatcher = null;
+
+    FORGE.BaseBinding.call(this, viewer, "AxisBinding", context, name);
+
+    this._boot();
+};
+
+FORGE.AxisBinding.prototype = Object.create(FORGE.BaseBinding.prototype);
+FORGE.AxisBinding.prototype.constructor = FORGE.AxisBinding;
+
+/**
+ * Boot sequence
+ * @method FORGE.AxisBinding#_boot
+ */
+FORGE.AxisBinding.prototype._boot = function()
+{
+    if (FORGE.Utils.isTypeOf(this._up, "string") === true || FORGE.Utils.isArrayOf(this._up, "string"))
+    {
+        this._moveActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onMove");
+        this._moveActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._up));
+    }
+};
+
+/**
+ * This method is called by the input associated when an axis is moved. This triggers the move
+ * callbacks associated to this binding.
+ * @method FORGE.AxisBinding#move
+ * @param {number} value - the value of the button
+ */
+FORGE.AxisBinding.prototype.move = function(value)
+{
+    this.log("move");
+
+    this._pressed = true;
+    this._moveCount++;
+
+    if (typeof this._move === "function")
+    {
+        // Call the callback with a reference to this binding + the original event.
+        this._move.call(this._context, this, value);
+    }
+    else if (this._moveActionEventDispatcher !== null)
+    {
+        this._moveActionEventDispatcher.dispatch();
+    }
+};
+
+/**
+ * Destroy sequence.
+ * @method  FORGE.AxisBinding#destroy
+ */
+FORGE.AxisBinding.prototype.destroy = function()
+{
+    this._move = null;
+
+    if (this._moveActionEventDispatcher !== null)
+    {
+        this._moveActionEventDispatcher.destroy();
+        this._moveActionEventDispatcher = null;
+    }
+
+    FORGE.BaseBinding.prototype.destroy.call(this);
+};
+
+
+/**
+ * Gets the axis associated to this binding.
+ * @name FORGE.AxisBinding#axis
+ * @type {number}
+ * @readonly
+ */
+Object.defineProperty(FORGE.AxisBinding.prototype, "axis",
+{
+    /** @this {FORGE.AxisBinding} **/
+    get: function()
+    {
+        return this._axis;
+    }
+});

--- a/src/input/binding/AxisBinding.js
+++ b/src/input/binding/AxisBinding.js
@@ -5,7 +5,7 @@
  * @constructor FORGE.AxisBinding
  * @param {FORGE.Viewer} viewer - the viewer reference
  * @param {number} axis - the axis code associated to this binding
- * @param {?(Function|string|Array<string>)} move - the callback function that will be called on an axis movement
+ * @param {?(Function|string|Array<string>)=} move - the callback function that will be called on an axis movement
  * @param {Object=} context - the context in which you want the callbacks to be executed
  * @param {string=} name - the name of the binding
  * @extends {FORGE.BaseBinding}
@@ -50,10 +50,10 @@ FORGE.AxisBinding.prototype.constructor = FORGE.AxisBinding;
  */
 FORGE.AxisBinding.prototype._boot = function()
 {
-    if (FORGE.Utils.isTypeOf(this._up, "string") === true || FORGE.Utils.isArrayOf(this._up, "string"))
+    if (FORGE.Utils.isTypeOf(this._move, "string") === true || FORGE.Utils.isArrayOf(this._move, "string"))
     {
         this._moveActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onMove");
-        this._moveActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._up));
+        this._moveActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._move));
     }
 };
 
@@ -68,7 +68,6 @@ FORGE.AxisBinding.prototype.move = function(value)
     this.log("move");
 
     this._pressed = true;
-    this._moveCount++;
 
     if (typeof this._move === "function")
     {

--- a/src/input/binding/AxisBinding.js
+++ b/src/input/binding/AxisBinding.js
@@ -5,12 +5,12 @@
  * @constructor FORGE.AxisBinding
  * @param {FORGE.Viewer} viewer - the viewer reference
  * @param {number} axis - the axis code associated to this binding
- * @param {?(Function|string|Array<string>)=} move - the callback function that will be called on an axis movement
+ * @param {?(Function|string|Array<string>)=} change - the callback function that will be called on an axis changement
  * @param {Object=} context - the context in which you want the callbacks to be executed
  * @param {string=} name - the name of the binding
  * @extends {FORGE.BaseBinding}
  */
-FORGE.AxisBinding = function(viewer, axis, move, context, name)
+FORGE.AxisBinding = function(viewer, axis, change, context, name)
 {
     /**
      * The axis code associated to this AxisBinding
@@ -21,20 +21,20 @@ FORGE.AxisBinding = function(viewer, axis, move, context, name)
     this._axis = axis;
 
     /**
-     * The callback function that will be called on an axis movement
-     * @name FORGE.AxisBinding#_move
+     * The callback function that will be called on an axis changement
+     * @name FORGE.AxisBinding#_change
      * @type {?(Function|string|Array<string>)}
      * @private
      */
-    this._move = move || null;
+    this._change = change || null;
 
     /**
-     * Action event dispatcher for move action
-     * @name FORGE.AxisBinding#_moveActionEventDispatcher
+     * Action event dispatcher for change action
+     * @name FORGE.AxisBinding#_changeActionEventDispatcher
      * @type {?FORGE.ActionEventDispatcher}
      * @private
      */
-    this._moveActionEventDispatcher = null;
+    this._changeActionEventDispatcher = null;
 
     FORGE.BaseBinding.call(this, viewer, "AxisBinding", context, name);
 
@@ -50,33 +50,33 @@ FORGE.AxisBinding.prototype.constructor = FORGE.AxisBinding;
  */
 FORGE.AxisBinding.prototype._boot = function()
 {
-    if (FORGE.Utils.isTypeOf(this._move, "string") === true || FORGE.Utils.isArrayOf(this._move, "string"))
+    if (FORGE.Utils.isTypeOf(this._change, "string") === true || FORGE.Utils.isArrayOf(this._change, "string"))
     {
-        this._moveActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onMove");
-        this._moveActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._move));
+        this._changeActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onChange");
+        this._changeActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._change));
     }
 };
 
 /**
- * This method is called by the input associated when an axis is moved. This triggers the move
+ * This method is called by the input associated when an axis is changed. This triggers the change
  * callbacks associated to this binding.
- * @method FORGE.AxisBinding#move
- * @param {number} value - the value of the button
+ * @method FORGE.AxisBinding#change
+ * @param {number} value - the value of the axis
  */
-FORGE.AxisBinding.prototype.move = function(value)
+FORGE.AxisBinding.prototype.change = function(value)
 {
-    this.log("move");
+    this.log("change");
 
     this._pressed = true;
 
-    if (typeof this._move === "function")
+    if (typeof this._change === "function")
     {
         // Call the callback with a reference to this binding + the original event.
-        this._move.call(this._context, this, value);
+        this._change.call(this._context, this, value);
     }
-    else if (this._moveActionEventDispatcher !== null)
+    else if (this._changeActionEventDispatcher !== null)
     {
-        this._moveActionEventDispatcher.dispatch();
+        this._changeActionEventDispatcher.dispatch();
     }
 };
 
@@ -86,12 +86,12 @@ FORGE.AxisBinding.prototype.move = function(value)
  */
 FORGE.AxisBinding.prototype.destroy = function()
 {
-    this._move = null;
+    this._change = null;
 
-    if (this._moveActionEventDispatcher !== null)
+    if (this._changeActionEventDispatcher !== null)
     {
-        this._moveActionEventDispatcher.destroy();
-        this._moveActionEventDispatcher = null;
+        this._changeActionEventDispatcher.destroy();
+        this._changeActionEventDispatcher = null;
     }
 
     FORGE.BaseBinding.prototype.destroy.call(this);

--- a/src/input/binding/BaseBinding.js
+++ b/src/input/binding/BaseBinding.js
@@ -1,0 +1,67 @@
+/**
+ * Base class for input bindings
+ *
+ * @constructor FORGE.BaseBinding
+ * @param {FORGE.Viewer} viewer - The viewer reference.
+ * @param {string=} className - The name of the class binding.
+ * @param {Object=} context - The context in which you want your callbacks to be executed.
+ * @param {string=} name - The name of the binding, can be use as an identifier.
+ * @extends {FORGE.BaseObject}
+ */
+FORGE.BaseBinding = function(viewer, className, context, name)
+{
+    /**
+     * Viewer reference
+     * @name  FORGE.BaseBinding#_viewer
+     * @type {FORGE.Viewer}
+     * @private
+     */
+    this._viewer = viewer;
+
+    /**
+     * The context in which we execute down, up and hold callback.
+     * @name  FORGE.BaseBinding#_context
+     * @type {Object}
+     * @private
+     */
+    this._context = context || this;
+
+    /**
+     * The name of the binding, can be usefull if multiple keycodes react for this binding.
+     * @name FORGE.BaseBinding#_name
+     * @type {string}
+     * @private
+     */
+    this._name = name || "";
+
+    FORGE.BaseObject.call(this, className);
+};
+
+FORGE.BaseBinding.prototype = Object.create(FORGE.BaseObject.prototype);
+FORGE.BaseBinding.prototype.constructor = FORGE.BaseBinding;
+
+/**
+ * Destroy sequence.
+ * @method FORGE.BaseBinding#destroy
+ */
+FORGE.BaseBinding.prototype.destroy = function()
+{
+    this._context = null;
+
+    FORGE.BaseObject.prototype.destroy.call(this);
+};
+
+/**
+ * Gets the name of this BaseBinding.
+ * @name FORGE.BaseBinding#name
+ * @readonly
+ * @type {string}
+ */
+Object.defineProperty(FORGE.BaseBinding.prototype, "name",
+{
+    /** @this {FORGE.BaseBinding} */
+    get: function()
+    {
+        return this._name;
+    }
+});

--- a/src/input/binding/BaseBinding.js
+++ b/src/input/binding/BaseBinding.js
@@ -65,3 +65,18 @@ Object.defineProperty(FORGE.BaseBinding.prototype, "name",
         return this._name;
     }
 });
+
+/**
+ * Gets the type of this BaseBinding.
+ * @name FORGE.BaseBinding#type
+ * @readonly
+ * @type {string}
+ */
+Object.defineProperty(FORGE.BaseBinding.prototype, "type",
+{
+    /** @this {FORGE.BaseBinding} */
+    get: function()
+    {
+        return this._className;
+    }
+});

--- a/src/input/binding/BaseBinding.js
+++ b/src/input/binding/BaseBinding.js
@@ -3,7 +3,7 @@
  *
  * @constructor FORGE.BaseBinding
  * @param {FORGE.Viewer} viewer - The viewer reference.
- * @param {string=} className - The name of the class binding.
+ * @param {string} className - The name of the class binding.
  * @param {Object=} context - The context in which you want your callbacks to be executed.
  * @param {string=} name - The name of the binding, can be use as an identifier.
  * @extends {FORGE.BaseObject}

--- a/src/input/binding/ButtonBinding.js
+++ b/src/input/binding/ButtonBinding.js
@@ -133,7 +133,7 @@ FORGE.ButtonBinding = function(viewer, buttonsIn, down, up, hold, buttonsOut, co
     this._boot();
 };
 
-FORGE.ButtonBinding.prototype = Object.create(FORGE.ButtonBinding.prototype);
+FORGE.ButtonBinding.prototype = Object.create(FORGE.BaseBinding.prototype);
 FORGE.ButtonBinding.prototype.constructor = FORGE.ButtonBinding;
 
 /**

--- a/src/input/binding/ButtonBinding.js
+++ b/src/input/binding/ButtonBinding.js
@@ -1,0 +1,408 @@
+/**
+ * Button binding object that handles buttons event for a list of buttons.
+ * To use a button binding, you have to add it to a {@link FORGE.Gamepad}.
+ *
+ * @constructor FORGE.ButtonBinding
+ * @param {FORGE.Viewer} viewer - the viewer referemce.
+ * @param {(Array<number>|number)} buttonsIn - The button code (or array) associated to this binding.
+ * @param {?(Function|string|Array<string>)=} down - The callback function that will be called on a button down event.
+ * @param {?(Function|string|Array<string>)=} up - The callback function that will be called on a button release event.
+ * @param {?(Function|string|Array<string>)=} hold - The callback function that will be called if a button is hold.
+ * @param {?(Array<number>|number)=} buttonsOut - The button code (or array) that will be rejected if the button is down.
+ * @param {Object=} context - The context in which you want your "down", "hold" & up callbacks to execute.
+ * @param {string=} name - The name of the binding, can be use as an identifier.
+ * @extends {FORGE.BaseBinding}
+ */
+FORGE.ButtonBinding = function(viewer, buttonsIn, down, up, hold, buttonsOut, context, name)
+{
+    /**
+     * The button code or array of button codes associated to this ButtonBinding.
+     * @name FORGE.ButtonBinding#_buttonsIn
+     * @type {?(Array<number>|number)}
+     * @private
+     */
+    this._buttonsIn = buttonsIn || [];
+
+    /**
+     * The callback function that will be called on a button down event.
+     * @name FORGE.ButtonBinding#_down
+     * @type {?(Function|string|Array<string>)}
+     * @private
+     */
+    this._down = down || null;
+
+    /**
+     * The callback function that will be called on a button up event.
+     * @name FORGE.ButtonBinding#_up
+     * @type {?(Function|string|Array<string>)}
+     * @private
+     */
+    this._up = up || null;
+
+    /**
+     * The callback function that will be called if a button is hold.
+     * @name FORGE.ButtonBinding#_hold
+     * @type {?(Function|string|Array<string>)}
+     * @private
+     */
+    this._hold = hold || null;
+
+    /**
+     * The button code or array of button codes that will be rejected if this ButtonBinding is down.
+     * @name FORGE.ButtonBinding#_buttonsOut
+     * @type {?(Array<number>|number)}
+     * @private
+     */
+    this._buttonsOut = buttonsOut || null;
+
+    /**
+     * Flag to know if we have to wait to consider a down event as a hold one.
+     * @name FORGE.ButtonBinding#_waitToHold
+     * @type {boolean}
+     * @private
+     */
+    this._waitToHold = false;
+
+    /**
+     * Flag to know if we have this button binding is considered as pressed.<br>
+     * It should be pressed if any of buttonsIn are pressed.
+     * @name FORGE.ButtonBinding#_pressed
+     * @type {boolean}
+     * @private
+     */
+    this._pressed = false;
+
+    /**
+     * When a button binding have to wait to be considered as holded this flag is check to know if down action is complete.
+     * @name FORGE.ButtonBinding#_downComplete
+     * @type {boolean}
+     * @private
+     */
+    this._downComplete = false;
+
+    /**
+     * Count of down.
+     * @name FORGE.ButtonBinding#_downCount
+     * @type {number}
+     * @private
+     */
+    this._downCount = 0;
+
+    /**
+     * Count of hold.
+     * @name FORGE.ButtonBinding#_holdCount
+     * @type {number}
+     * @private
+     */
+    this._holdCount = 0;
+
+    /**
+     * Count of up.
+     * @name FORGE.ButtonBinding#_upCount
+     * @type {number}
+     * @private
+     */
+    this._upCount = 0;
+
+    /**
+     * Action event dispatcher for down action
+     * @name FORGE.ButtonBinding#_downActionEventDispatcher
+     * @type {?FORGE.ActionEventDispatcher}
+     * @private
+     */
+    this._downActionEventDispatcher = null;
+
+    /**
+     * Action event dispatcher for hold action
+     * @name FORGE.ButtonBinding#_holdActionEventDispatcher
+     * @type {?FORGE.ActionEventDispatcher}
+     * @private
+     */
+    this._holdActionEventDispatcher = null;
+
+    /**
+     * Action event dispatcher for up action
+     * @name FORGE.ButtonBinding#_upActionEventDispatcher
+     * @type {?FORGE.ActionEventDispatcher}
+     * @private
+     */
+    this._upActionEventDispatcher = null;
+
+    FORGE.BaseBinding.call(this, viewer, "ButtonBinding", context, name);
+
+    this._boot();
+};
+
+FORGE.ButtonBinding.prototype = Object.create(FORGE.ButtonBinding.prototype);
+FORGE.ButtonBinding.prototype.constructor = FORGE.ButtonBinding;
+
+/**
+ * Boot sequence
+ * @method FORGE.ButtonBinding#_boot
+ */
+FORGE.ButtonBinding.prototype._boot = function()
+{
+    if (FORGE.Utils.isTypeOf(this._down, "string") === true || FORGE.Utils.isArrayOf(this._down, "string"))
+    {
+        this._downActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onPressed");
+        this._downActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._down));
+    }
+
+    if (FORGE.Utils.isTypeOf(this._hold, "string") === true || FORGE.Utils.isArrayOf(this._hold, "string"))
+    {
+        this._holdActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onHold");
+        this._holdActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._hold));
+    }
+
+    if (FORGE.Utils.isTypeOf(this._up, "string") === true || FORGE.Utils.isArrayOf(this._up, "string"))
+    {
+        this._upActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onReleased");
+        this._upActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._up));
+    }
+};
+
+/**
+ * Know if a button is associated to this binding by being in.
+ * @method FORGE.ButtonBinding#hasButtonIn
+ * @param {number} button - the code of the button to check
+ * @return {boolean} true if associated, else false
+ */
+FORGE.ButtonBinding.prototype.hasButtonIn = function(button)
+{
+    return this._buttonsIn === button ||
+        (typeof this._buttonsIn.indexOf === "function" && this._buttonsIn.indexOf(button) !== -1);
+};
+
+/**
+ * Know if a button is associated to this binding by being out.
+ * @method FORGE.ButtonBinding#hasButtonOut
+ * @param {number} button - the code of the button to check
+ * @return {boolean} true if associated, else false
+ */
+FORGE.ButtonBinding.prototype.hasButtonOut = function(button)
+{
+    return this._buttonsOut !== null &&
+        (this._buttonsOut === button ||
+            (typeof this._buttonsOut.indexOf === "function" && this._buttonsOut.indexOf(button) !== -1));
+};
+
+/**
+ * This method is called by the input associated when a button is down. This triggers the
+ * down callback associated to this binding and increases the downCount value.
+ * @method FORGE.ButtonBinding#down
+ * @param {number} value - the value of the button
+ */
+FORGE.ButtonBinding.prototype.down = function(value)
+{
+    this.log("down");
+
+    this._pressed = true;
+    this._downCount++;
+
+    if (typeof this._down === "function")
+    {
+        // Call the callback with a reference to this binding + the original event.
+        this._down.call(this._context, this, value);
+    }
+    else if (this._downActionEventDispatcher !== null)
+    {
+        this._downActionEventDispatcher.dispatch();
+    }
+};
+
+/**
+ * This method is called by the input associated when a button is hold. This triggers the
+ * hold callback associated to this binding and increases the holdCount value.
+ * @method FORGE.ButtonBinding#hold
+ * @param {number} value - the value of the button
+ */
+FORGE.ButtonBinding.prototype.hold = function(value)
+{
+    this.log("hold");
+
+    this._holdCount++;
+
+    if (typeof this._hold === "function")
+    {
+        // Call the callback with a reference to this binding + the original event.
+        this._hold.call(this._context, this, value);
+    }
+    else if (this._holdActionEventDispatcher !== null)
+    {
+        this._holdActionEventDispatcher.dispatch();
+    }
+};
+
+/**
+ * This method is called by the input associated when a button is up. This triggers the
+ * up callback associated to this binding and increases the upCount value.
+ * @method FORGE.ButtonBinding#up
+ * @param {number} value - the value of the button
+ */
+FORGE.ButtonBinding.prototype.up = function(value)
+{
+    this.log("up");
+
+    this._pressed = false;
+    this._downComplete = false;
+    this._upCount++;
+
+    if (typeof this._up === "function")
+    {
+        // Call the callback with a reference to this binding + the original event.
+        this._up.call(this._context, this, value);
+    }
+    else if (this._upActionEventDispatcher !== null)
+    {
+        this._upActionEventDispatcher.dispatch();
+    }
+};
+
+/**
+ * This method has to be called by the user down callback to specify that the button down have to
+ * wait to be considered as holded.<br>
+ * This gives in return a callback to set the down as complete.
+ * @method FORGE.ButtonBinding#waitToHold
+ * @return {Function} Returns a callback function that the user have to call to set the down as complete to allow hold.
+ */
+FORGE.ButtonBinding.prototype.waitToHold = function()
+{
+    this._waitToHold = true;
+
+    var _downCount = this._downCount;
+
+    var downCompleteCallback = function()
+    {
+        this.log("downCompleteCallback " + _downCount + " " + this._downCount);
+
+        if (_downCount === this._downCount)
+        {
+            this._downComplete = true;
+        }
+    };
+
+    return downCompleteCallback.bind(this);
+};
+
+/**
+ * Destroy sequence.
+ * @method  FORGE.ButtonBinding#destroy
+ */
+FORGE.ButtonBinding.prototype.destroy = function()
+{
+    this._buttonsIn = null;
+    this._down = null;
+    this._up = null;
+    this._hold = null;
+    this._buttonsOut = null;
+
+    if (this._downActionEventDispatcher !== null)
+    {
+        this._downActionEventDispatcher.destroy();
+        this._downActionEventDispatcher = null;
+    }
+
+    if (this._holdActionEventDispatcher !== null)
+    {
+        this._holdActionEventDispatcher.destroy();
+        this._holdActionEventDispatcher = null;
+    }
+
+    if (this._upActionEventDispatcher !== null)
+    {
+        this._upActionEventDispatcher.destroy();
+        this._upActionEventDispatcher = null;
+    }
+
+    FORGE.BaseBinding.prototype.destroy.call(this);
+};
+
+/**
+ * Gets the pressed status of this ButtonBinding.
+ * @name FORGE.ButtonBinding#pressed
+ * @readonly
+ * @type {boolean}
+ */
+Object.defineProperty(FORGE.ButtonBinding.prototype, "pressed",
+{
+    /** @this {FORGE.ButtonBinding} */
+    get: function()
+    {
+        return this._pressed;
+    }
+});
+
+/**
+ * Gets the down count value.
+ * @name FORGE.ButtonBinding#downCount
+ * @readonly
+ * @type {number}
+ */
+Object.defineProperty(FORGE.ButtonBinding.prototype, "downCount",
+{
+    /** @this {FORGE.ButtonBinding} */
+    get: function()
+    {
+        return this._downCount;
+    }
+});
+
+/**
+ * Gets the up count value.
+ * @name FORGE.ButtonBinding#upCount
+ * @readonly
+ * @type {number}
+ */
+Object.defineProperty(FORGE.ButtonBinding.prototype, "upCount",
+{
+    /** @this {FORGE.ButtonBinding} */
+    get: function()
+    {
+        return this._upCount;
+    }
+});
+
+/**
+ * Gets the hold count value.
+ * @name FORGE.ButtonBinding#holdCount
+ * @readonly
+ * @type {number}
+ */
+Object.defineProperty(FORGE.ButtonBinding.prototype, "holdCount",
+{
+    /** @this {FORGE.ButtonBinding} */
+    get: function()
+    {
+        return this._holdCount;
+    }
+});
+
+/**
+ * Gets the hasToWaitToHold value.
+ * @name FORGE.ButtonBinding#hasToWaitToHold
+ * @readonly
+ * @type {boolean}
+ */
+Object.defineProperty(FORGE.ButtonBinding.prototype, "hasToWaitToHold",
+{
+    /** @this {FORGE.ButtonBinding} */
+    get: function()
+    {
+        return this._waitToHold;
+    }
+});
+
+/**
+ * Gets the downComplete value.
+ * @name FORGE.ButtonBinding#downComplete
+ * @readonly
+ * @type {boolean}
+ */
+Object.defineProperty(FORGE.ButtonBinding.prototype, "downComplete",
+{
+    /** @this {FORGE.ButtonBinding} */
+    get: function()
+    {
+        return this._downComplete;
+    }
+});

--- a/src/input/binding/ButtonBinding.js
+++ b/src/input/binding/ButtonBinding.js
@@ -214,9 +214,8 @@ FORGE.ButtonBinding.prototype.down = function(value)
  * This method is called by the input associated when a button is hold. This triggers the
  * hold callback associated to this binding and increases the holdCount value.
  * @method FORGE.ButtonBinding#hold
- * @param {number} value - the value of the button
  */
-FORGE.ButtonBinding.prototype.hold = function(value)
+FORGE.ButtonBinding.prototype.hold = function()
 {
     this.log("hold");
 
@@ -225,7 +224,7 @@ FORGE.ButtonBinding.prototype.hold = function(value)
     if (typeof this._hold === "function")
     {
         // Call the callback with a reference to this binding + the original event.
-        this._hold.call(this._context, this, value);
+        this._hold.call(this._context, this);
     }
     else if (this._holdActionEventDispatcher !== null)
     {

--- a/src/input/binding/ButtonBinding.js
+++ b/src/input/binding/ButtonBinding.js
@@ -21,7 +21,7 @@ FORGE.ButtonBinding = function(viewer, buttonsIn, down, up, hold, buttonsOut, co
      * @type {?(Array<number>|number)}
      * @private
      */
-    this._buttonsIn = buttonsIn || [];
+    this._buttonsIn = buttonsIn;
 
     /**
      * The callback function that will be called on a button down event.
@@ -50,10 +50,10 @@ FORGE.ButtonBinding = function(viewer, buttonsIn, down, up, hold, buttonsOut, co
     /**
      * The button code or array of button codes that will be rejected if this ButtonBinding is down.
      * @name FORGE.ButtonBinding#_buttonsOut
-     * @type {?(Array<number>|number)}
+     * @type {?(Array<number>|number|undefined)}
      * @private
      */
-    this._buttonsOut = buttonsOut || null;
+    this._buttonsOut = buttonsOut;
 
     /**
      * Flag to know if we have to wait to consider a down event as a hold one.
@@ -142,6 +142,16 @@ FORGE.ButtonBinding.prototype.constructor = FORGE.ButtonBinding;
  */
 FORGE.ButtonBinding.prototype._boot = function()
 {
+    if (typeof this._buttonsIn === "undefined" || this._buttonsIn === null)
+    {
+        this._buttonsIn = [];
+    }
+
+    if (typeof this._buttonsOut === "undefined")
+    {
+        this._buttonsOut = null;
+    }
+
     if (FORGE.Utils.isTypeOf(this._down, "string") === true || FORGE.Utils.isArrayOf(this._down, "string"))
     {
         this._downActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onPressed");

--- a/src/input/binding/KeyBinding.js
+++ b/src/input/binding/KeyBinding.js
@@ -1,4 +1,3 @@
-
 /**
  * Key Binding object that handles keyboard event handlers for a list of keycodes.
  * To use a Key Binding you have to add it to the {@link FORGE.Keyboard}.
@@ -12,18 +11,10 @@
  * @param {?(Array<number>|number)=} keysOut - The key code or array of key codes that will be rejected if this KeyBinding is pressed.
  * @param {Object=} context - The context in which you want your "down", "hold" & up callbacks to execute
  * @param {string=} name - The name of the binding, can be use as an identifier.
- * @extends {FORGE.BaseObject}
+ * @extends {FORGE.BaseBinding}
  */
 FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, name)
 {
-    /**
-     * Viewer reference
-     * @name  FORGE.KeyBinding#_viewer
-     * @type {FORGE.Viewer}
-     * @private
-     */
-    this._viewer = viewer;
-
     /**
      * The key code or array of key codes associated to this KeyBinding.
      * @name FORGE.KeyBinding#_keysIn
@@ -63,22 +54,6 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * @private
      */
     this._keysOut = keysOut || null;
-
-    /**
-     * The context in which we execute down, up and hold callback.
-     * @name  FORGE.KeyBinding#_context
-     * @type {Object}
-     * @private
-     */
-    this._context = context || this;
-
-    /**
-     * The name of the binding, can be usefull if multiple keycodes react for this binding.
-     * @name FORGE.KeyBinding#_name
-     * @type {string}
-     * @private
-     */
-    this._name = name || "";
 
     /**
      * Flag to know if we have to wait to consider a down event as a holded one.
@@ -159,12 +134,12 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      */
     this._upActionEventDispatcher = null;
 
-    FORGE.BaseObject.call(this, "KeyBinding");
+    FORGE.BaseBinding.call(this, viewer, "KeyBinding", context, name);
 
     this._boot();
 };
 
-FORGE.KeyBinding.prototype = Object.create(FORGE.BaseObject.prototype);
+FORGE.KeyBinding.prototype = Object.create(FORGE.BaseBinding.prototype);
 FORGE.KeyBinding.prototype.constructor = FORGE.KeyBinding;
 
 /**
@@ -173,22 +148,22 @@ FORGE.KeyBinding.prototype.constructor = FORGE.KeyBinding;
  */
 FORGE.KeyBinding.prototype._boot = function()
 {
-    if(FORGE.Utils.isTypeOf(this._down, "string") === true || FORGE.Utils.isArrayOf(this._down, "string"))
+    if (FORGE.Utils.isTypeOf(this._down, "string") === true || FORGE.Utils.isArrayOf(this._down, "string"))
     {
         this._downActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onDown");
-        this._downActionEventDispatcher.addActions(/** @type {(string|Array<string>)} */ (this._down));
+        this._downActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._down));
     }
 
-    if(FORGE.Utils.isTypeOf(this._hold, "string") === true || FORGE.Utils.isArrayOf(this._hold, "string"))
+    if (FORGE.Utils.isTypeOf(this._hold, "string") === true || FORGE.Utils.isArrayOf(this._hold, "string"))
     {
         this._holdActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onHold");
-        this._holdActionEventDispatcher.addActions(/** @type {(string|Array<string>)} */ (this._hold));
+        this._holdActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._hold));
     }
 
-    if(FORGE.Utils.isTypeOf(this._up, "string") === true || FORGE.Utils.isArrayOf(this._up, "string"))
+    if (FORGE.Utils.isTypeOf(this._up, "string") === true || FORGE.Utils.isArrayOf(this._up, "string"))
     {
         this._upActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onUp");
-        this._upActionEventDispatcher.addActions(/** @type {(string|Array<string>)} */ (this._up));
+        this._upActionEventDispatcher.addActions( /** @type {(string|Array<string>)} */ (this._up));
     }
 };
 
@@ -200,7 +175,7 @@ FORGE.KeyBinding.prototype._boot = function()
  */
 FORGE.KeyBinding.prototype.hasKeyIn = function(keyCode)
 {
-    if(typeof this._keysIn === "number" && this._keysIn === keyCode)
+    if (typeof this._keysIn === "number" && this._keysIn === keyCode)
     {
         return true;
     }
@@ -220,11 +195,11 @@ FORGE.KeyBinding.prototype.hasKeyIn = function(keyCode)
  */
 FORGE.KeyBinding.prototype.hasKeyOut = function(keyCode)
 {
-    if(this._keysOut === null)
+    if (this._keysOut === null)
     {
         return false;
     }
-    else if(typeof this._keysOut === "number" && this._keysOut === keyCode)
+    else if (typeof this._keysOut === "number" && this._keysOut === keyCode)
     {
         return true;
     }
@@ -249,12 +224,12 @@ FORGE.KeyBinding.prototype.down = function(event)
     this._downCount++;
     this._pressed = true;
 
-    if(typeof this._down === "function")
+    if (typeof this._down === "function")
     {
         //Call the callback with a reference to this binding + the original event.
         this._down.call(this._context, this, event);
     }
-    else if(this._downActionEventDispatcher !== null)
+    else if (this._downActionEventDispatcher !== null)
     {
         this._downActionEventDispatcher.dispatch();
     }
@@ -274,9 +249,9 @@ FORGE.KeyBinding.prototype.waitToHold = function()
 
     var downCompleteCallback = function()
     {
-        this.log("downCompleteCallback "+_downCount+" "+this._downCount);
+        this.log("downCompleteCallback " + _downCount + " " + this._downCount);
 
-        if(_downCount === this._downCount)
+        if (_downCount === this._downCount)
         {
             this._downComplete = true;
         }
@@ -299,12 +274,12 @@ FORGE.KeyBinding.prototype.up = function(event)
     this._pressed = false;
     this._downComplete = false;
 
-    if(typeof this._up === "function")
+    if (typeof this._up === "function")
     {
         //Call the callback with a reference to this binding + the original event.
         this._up.call(this._context, this, event);
     }
-    else if(this._upActionEventDispatcher !== null)
+    else if (this._upActionEventDispatcher !== null)
     {
         this._upActionEventDispatcher.dispatch();
     }
@@ -321,11 +296,11 @@ FORGE.KeyBinding.prototype.hold = function()
 
     this._holdCount++;
 
-    if(typeof this._hold === "function")
+    if (typeof this._hold === "function")
     {
         this._hold.call(this._context, this);
     }
-    else if(this._holdActionEventDispatcher !== null)
+    else if (this._holdActionEventDispatcher !== null)
     {
         this._holdActionEventDispatcher.dispatch();
     }
@@ -342,50 +317,34 @@ FORGE.KeyBinding.prototype.destroy = function()
     this._up = null;
     this._hold = null;
     this._keysOut = null;
-    this._context = null;
 
-    if(this._downActionEventDispatcher !== null)
+    if (this._downActionEventDispatcher !== null)
     {
         this._downActionEventDispatcher.destroy();
         this._downActionEventDispatcher = null;
     }
 
-    if(this._holdActionEventDispatcher !== null)
+    if (this._holdActionEventDispatcher !== null)
     {
         this._holdActionEventDispatcher.destroy();
         this._holdActionEventDispatcher = null;
     }
 
-    if(this._upActionEventDispatcher !== null)
+    if (this._upActionEventDispatcher !== null)
     {
         this._upActionEventDispatcher.destroy();
         this._upActionEventDispatcher = null;
     }
 
-    FORGE.BaseObject.prototype.destroy.call(this);
+    FORGE.BaseBinding.prototype.destroy.call(this);
 };
 
 /**
-* Gets the name of this KeyBinding.
-* @name FORGE.KeyBinding#name
-* @readonly
-* @type {string}
-*/
-Object.defineProperty(FORGE.KeyBinding.prototype, "name",
-{
-    /** @this {FORGE.KeyBinding} */
-    get: function()
-    {
-        return this._name;
-    }
-});
-
-/**
-* Gets the pressed status of this KeyBinding.
-* @name FORGE.KeyBinding#pressed
-* @readonly
-* @type {boolean}
-*/
+ * Gets the pressed status of this KeyBinding.
+ * @name FORGE.KeyBinding#pressed
+ * @readonly
+ * @type {boolean}
+ */
 Object.defineProperty(FORGE.KeyBinding.prototype, "pressed",
 {
     /** @this {FORGE.KeyBinding} */
@@ -396,11 +355,11 @@ Object.defineProperty(FORGE.KeyBinding.prototype, "pressed",
 });
 
 /**
-* Gets the down count value.
-* @name FORGE.KeyBinding#downCount
-* @readonly
-* @type {number}
-*/
+ * Gets the down count value.
+ * @name FORGE.KeyBinding#downCount
+ * @readonly
+ * @type {number}
+ */
 Object.defineProperty(FORGE.KeyBinding.prototype, "downCount",
 {
     /** @this {FORGE.KeyBinding} */
@@ -411,11 +370,11 @@ Object.defineProperty(FORGE.KeyBinding.prototype, "downCount",
 });
 
 /**
-* Gets the up count value.
-* @name FORGE.KeyBinding#upCount
-* @readonly
-* @type {number}
-*/
+ * Gets the up count value.
+ * @name FORGE.KeyBinding#upCount
+ * @readonly
+ * @type {number}
+ */
 Object.defineProperty(FORGE.KeyBinding.prototype, "upCount",
 {
     /** @this {FORGE.KeyBinding} */
@@ -426,11 +385,11 @@ Object.defineProperty(FORGE.KeyBinding.prototype, "upCount",
 });
 
 /**
-* Gets the hold count value.
-* @name FORGE.KeyBinding#holdCount
-* @readonly
-* @type {number}
-*/
+ * Gets the hold count value.
+ * @name FORGE.KeyBinding#holdCount
+ * @readonly
+ * @type {number}
+ */
 Object.defineProperty(FORGE.KeyBinding.prototype, "holdCount",
 {
     /** @this {FORGE.KeyBinding} */
@@ -441,11 +400,11 @@ Object.defineProperty(FORGE.KeyBinding.prototype, "holdCount",
 });
 
 /**
-* Gets the hasToWaitToHold value.
-* @name FORGE.KeyBinding#hasToWaitToHold
-* @readonly
-* @type {boolean}
-*/
+ * Gets the hasToWaitToHold value.
+ * @name FORGE.KeyBinding#hasToWaitToHold
+ * @readonly
+ * @type {boolean}
+ */
 Object.defineProperty(FORGE.KeyBinding.prototype, "hasToWaitToHold",
 {
     /** @this {FORGE.KeyBinding} */
@@ -456,11 +415,11 @@ Object.defineProperty(FORGE.KeyBinding.prototype, "hasToWaitToHold",
 });
 
 /**
-* Gets the downComplete value.
-* @name FORGE.KeyBinding#downComplete
-* @readonly
-* @type {boolean}
-*/
+ * Gets the downComplete value.
+ * @name FORGE.KeyBinding#downComplete
+ * @readonly
+ * @type {boolean}
+ */
 Object.defineProperty(FORGE.KeyBinding.prototype, "downComplete",
 {
     /** @this {FORGE.KeyBinding} */

--- a/src/input/binding/KeyBinding.js
+++ b/src/input/binding/KeyBinding.js
@@ -59,7 +59,6 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * Flag to know if we have to wait to consider a down event as a holded one.
      * @name FORGE.KeyBinding#_waitToHold
      * @type {boolean}
-     * @default
      * @private
      */
     this._waitToHold = false;
@@ -69,7 +68,6 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * It should be pressed if any of keysIn are pressed.
      * @name FORGE.KeyBinding#_pressed
      * @type {boolean}
-     * @default
      * @private
      */
     this._pressed = false;
@@ -78,7 +76,6 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * When a key binding have to wait to be considered as holded this flag is check to know if down action is complete.
      * @name FORGE.KeyBinding#_downComplete
      * @type {boolean}
-     * @default
      * @private
      */
     this._downComplete = false;
@@ -87,7 +84,6 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * Count of down.
      * @name FORGE.KeyBinding#_downCount
      * @type {number}
-     * @default
      * @private
      */
     this._downCount = 0;
@@ -96,7 +92,6 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * Count of hold.
      * @name FORGE.KeyBinding#_holdCount
      * @type {number}
-     * @default
      * @private
      */
     this._holdCount = 0;
@@ -105,7 +100,6 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * Count of up.
      * @name FORGE.KeyBinding#_upCount
      * @type {number}
-     * @default
      * @private
      */
     this._upCount = 0;

--- a/src/input/binding/KeyBinding.js
+++ b/src/input/binding/KeyBinding.js
@@ -21,7 +21,7 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
      * @type {?(Array<number>|number)}
      * @private
      */
-    this._keysIn = keysIn || [];
+    this._keysIn = keysIn;
 
     /**
      * The callback function that will be called on a keydown event.
@@ -50,10 +50,10 @@ FORGE.KeyBinding = function(viewer, keysIn, down, up, hold, keysOut, context, na
     /**
      * The key code or array of key codes that will be rejected if this KeyBinding is pressed.
      * @name FORGE.KeyBinding#_keysOut
-     * @type {?(Array<number>|number)}
+     * @type {?(Array<number>|number|undefined)}
      * @private
      */
-    this._keysOut = keysOut || null;
+    this._keysOut = keysOut;
 
     /**
      * Flag to know if we have to wait to consider a down event as a holded one.
@@ -142,6 +142,16 @@ FORGE.KeyBinding.prototype.constructor = FORGE.KeyBinding;
  */
 FORGE.KeyBinding.prototype._boot = function()
 {
+    if (typeof this._keysIn === "undefined" || this._keysIn === null)
+    {
+        this._keysIn = [];
+    }
+
+    if (typeof this._keysOut === "undefined")
+    {
+        this._keysOut = null;
+    }
+
     if (FORGE.Utils.isTypeOf(this._down, "string") === true || FORGE.Utils.isArrayOf(this._down, "string"))
     {
         this._downActionEventDispatcher = new FORGE.ActionEventDispatcher(this._viewer, "onDown");

--- a/tools/reference/pages.json
+++ b/tools/reference/pages.json
@@ -65,7 +65,13 @@
                 "controller-options-zoom",
                 "controller-keyboard",
                 "controller-keyboard-binding",
-                "controller-keyboard-binding-events"
+                "controller-keyboard-binding-events",
+                "controller-gamepad",
+                "controller-gamepad-binding",
+                "controller-gamepad-button-binding",
+                "controller-gamepad-button-binding-events",
+                "controller-gamepad-axis-binding",
+                "controller-gamepad-axis-binding-events"
             ]
         },
         {
@@ -298,7 +304,13 @@
                 "controller-options-zoom",
                 "controller-keyboard",
                 "controller-keyboard-binding",
-                "controller-keyboard-binding-events"
+                "controller-keyboard-binding-events",
+                "controller-gamepad",
+                "controller-gamepad-binding",
+                "controller-gamepad-button-binding",
+                "controller-gamepad-button-binding-events",
+                "controller-gamepad-axis-binding",
+                "controller-gamepad-axis-binding-events"
             ]
         }]
     },

--- a/tools/reference/pages.json
+++ b/tools/reference/pages.json
@@ -300,6 +300,7 @@
                 "controller",
                 "controller-instance",
                 "controller-pointer",
+                "controller-options-orientation",
                 "controller-options-orientation-invert",
                 "controller-options-zoom",
                 "controller-keyboard",


### PR DESCRIPTION
Following the specification (https://www.w3.org/TR/gamepad/ and https://w3c.github.io/gamepad/extensions.html), I added a gamepad interface to the list of available  controllers. It was necessary to add it to have a base for support of Oculus, Vive and maybe other controllers of gamepad type with spatial positioning in the future.

There are two new types of binding with a gamepad (a third to come later):

- on buttons, which work a lot like keys, with three events: `onDown`, `onHold`, `onUp`
- on axis, which is different but simpler to treat as there is only one action on it: `onChange`

This is a WIP, but I'm making the code visible now as it is a relatively big chunk of code.