### PR TITLE
BackgroundRenderer fix entering VR in equi

### DIFF
--- a/src/render/background/BackgroundMeshRenderer.js
+++ b/src/render/background/BackgroundMeshRenderer.js
@@ -142,6 +142,11 @@ FORGE.BackgroundMeshRenderer.prototype._boot = function()
  */
 FORGE.BackgroundMeshRenderer.prototype._setDisplayObject = function(displayObject)
 {
+    if (this._mesh === null) 
+    {
+        this._updateInternals();
+    }
+
     this._displayObject = displayObject;
 
     if (FORGE.Utils.isTypeOf(displayObject, "Image"))

--- a/src/render/background/BackgroundRenderer.js
+++ b/src/render/background/BackgroundRenderer.js
@@ -199,7 +199,7 @@ FORGE.BackgroundRenderer.prototype.render = function(camera)
  */
 FORGE.BackgroundRenderer.prototype.update = function()
 {
-    if (!(this._mesh.material instanceof THREE.ShaderMaterial))
+    if (this._mesh === null || !(this._mesh.material instanceof THREE.ShaderMaterial))
     {
         return;
     }


### PR DESCRIPTION
- setDisplayObject now update internals when mesh is not already set
- render checks if mesh exists before doing anything