### PR TITLE
 Fix bug: viewer callbacks minification not fully described

### DIFF
--- a/externs/forge/core.ext.js
+++ b/externs/forge/core.ext.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {{boot:function(), update:function()}}
+ * @typedef {{boot:function(), update:function(), beforeRender:function(), afterRender:function()}}
  * @name ViewerCallbacks
  * @property {function} boot
  * @property {function} update


### PR DESCRIPTION
Core viewer objects constructor takes an object with callbacks as argument.
Allowed properties are: boot, update, beforeRender and afterRender.

Extern declaration was missing beforeRender and afterRender, and it was not usable with minified version of forge.
