### PR TITLE
Alps 282 - Cache management for multi resolution

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,7 @@ module.exports = function(grunt)
 
         "src/media/MediaType.js",
         "src/media/MediaFormat.js",
+        "src/media/MediaStore.js",
         "src/media/Media.js",
 
         "src/render/RenderManager.js",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,7 @@ module.exports = function(grunt)
         "src/media/MediaType.js",
         "src/media/MediaFormat.js",
         "src/media/MediaStore.js",
+        "src/media/MediaTexture.js",
         "src/media/Media.js",
 
         "src/render/RenderManager.js",

--- a/reference/scene/scene-media-level.json
+++ b/reference/scene/scene-media-level.json
@@ -9,7 +9,7 @@
         "name": {
             "type": "string",
             "title": "Name",
-            "description": "If set, specifies the <code>{z}</code> pattern for this level. If not, the value will be the index of the level in the levels array.",
+            "description": "If set, specifies the <code>{level}</code> pattern for this level. If not, the value will be the index of the level in the levels array.",
             "example": "4K"
         },
 

--- a/reference/scene/scene-media-source.json
+++ b/reference/scene/scene-media-source.json
@@ -36,8 +36,8 @@
         "pattern": {
             "type": "string",
             "title": "Pattern",
-            "description": "The pattern to respect in case of a multi tiles media. Four parameters are authorized:<ul><li><code>{f}</code> is for the face, in case of a cubemap media</li><li><code>{z}</code> is for the quality of the tile, in case of a multi resolution media</li><li><code>{x}</code> if for the <b>x</b> coordinates of the tile</li><li><code>{y}</code> if for the <b>y</b> coordinates of the tile</li>",
-            "example": "multi/equi/{z}/{y}/{x}.jpg"
+            "description": "The pattern to respect in case of a multi tiles media. Four parameters are authorized:<ul><li><code>{face}</code> is for the face, in case of a cubemap media</li><li><code>{level}</code> is for the level of quality of the tile, in case of a multi resolution media</li><li><code>{x}</code> if for the <b>x</b> coordinates of the tile</li><li><code>{y}</code> if for the <b>y</b> coordinates of the tile</li>",
+            "example": "multi/equi/{level}/{y}/{x}.jpg"
         },
 
         "levels": {

--- a/src/media/Media.js
+++ b/src/media/Media.js
@@ -50,6 +50,14 @@ FORGE.Media = function(viewer, config)
     this._displayObject = null;
 
     /**
+     * Media store reference, if it is a multi resolution image.
+     * @name FORGE.Media#_store
+     * @type {FORGE.MediaStore}
+     * @private
+     */
+    this._store = null;
+
+    /**
      * Loaded flag
      * @name FORGE.Media#_loaded
      * @type {boolean}
@@ -134,19 +142,10 @@ FORGE.Media.prototype._parseConfig = function(config)
         // If there isn't an URL set, it means that this is a multi resolution image.
         if (!source.url)
         {
-            throw "Multi resolution not implemented yet !";
+            this._store = new FORGE.MediaStore(this._viewer, source);
         }
-
-        if (source.format === FORGE.MediaFormat.EQUIRECTANGULAR)
-        {
-            imageConfig = {
-                key: this._uid,
-                url: source.url
-            };
-
-            this._displayObject = new FORGE.Image(this._viewer, imageConfig);
-        }
-        else if (source.format === FORGE.MediaFormat.CUBE ||
+        else if (source.format === FORGE.MediaFormat.EQUIRECTANGULAR ||
+            source.format === FORGE.MediaFormat.CUBE ||
             source.format === FORGE.MediaFormat.FLAT)
         {
             imageConfig = {
@@ -155,14 +154,13 @@ FORGE.Media.prototype._parseConfig = function(config)
             };
 
             this._displayObject = new FORGE.Image(this._viewer, imageConfig);
+            this._displayObject.onLoadComplete.addOnce(this._onImageLoadComplete, this);
         }
-
         else
         {
             throw "Media format not supported";
         }
 
-        this._displayObject.onLoadComplete.addOnce(this._onImageLoadComplete, this);
         return;
     }
 
@@ -270,6 +268,12 @@ FORGE.Media.prototype.destroy = function()
         this._displayObject = null;
     }
 
+    if (this._store !== null)
+    {
+        this._store.destroy();
+        this._store = null;
+    }
+
     if (this._onLoadComplete !== null)
     {
         this._onLoadComplete.destroy();
@@ -321,6 +325,21 @@ Object.defineProperty(FORGE.Media.prototype, "displayObject",
     get: function()
     {
         return this._displayObject;
+    }
+});
+
+/**
+ * Get the media store, if this is a multi resolution media.
+ * @name FORGE.Media#store
+ * @type {FORGE.MediaStore}
+ * @readonly
+ */
+Object.defineProperty(FORGE.Media.prototype, "store",
+{
+    /** @this {FORGE.Media} */
+    get: function()
+    {
+        return this._store;
     }
 });
 

--- a/src/media/MediaStore.js
+++ b/src/media/MediaStore.js
@@ -1,7 +1,7 @@
 /**
  * This object stores a number of tiles used for multi resolution cases with
  * tiles. It acts as a LRU map, as we can't store infinite amount of tiles.
- * The number of tiles to store is (6 * 2^n)!, with n being the number of levels.
+ * The number of tiles to store is (6 * 4^n)!, with n being the number of levels.
  *
  * There is an exception though: the level 0 of a multi resolution is always
  * kept in the cache.
@@ -31,21 +31,21 @@ FORGE.MediaStore = function(viewer, config)
     this._config = config;
 
     /**
-     * A map containing all {@link FORGE.Image}, with the key being constitued
-     * from the level, face, x and y properties defining the image
-     * @name FORGE.MediaStore#_images
+     * A map containing all {@link FORGE.MediaTexture}, with the key being constitued
+     * from the level, face, x and y properties defining the texture
+     * @name FORGE.MediaStore#_textures
      * @type {?FORGE.Map}
      * @private
      */
-    this._images = null;
+    this._textures = null;
 
     /**
-     * The maximum size of the store
-     * @name FORGE.MediaStore#_maxSize
+     * The current size of all loaded textures.
+     * @name FORGE.MediaStore#_size
      * @type {number}
      * @private
      */
-    this._maxSize = 0;
+    this._size = 0;
 
     /**
      * The pattern to follow to laod the images
@@ -64,6 +64,15 @@ FORGE.MediaStore.prototype = Object.create(FORGE.BaseObject.prototype);
 FORGE.MediaStore.prototype.constructor = FORGE.MediaStore;
 
 /**
+ * The maximum size of texture at once. It is set at 30Mb, as we assume the
+ * median size of a cache is 32Mb, and we keep 2Mb for other texture.
+ * @name FORGE.MediaStore.MAX_SIZE
+ * @type {string}
+ * @const
+ */
+FORGE.MediaStore.MAX_SIZE = 31457280;
+
+/**
  * Boot routine.
  *
  * @method FORGE.MediaStore#_boot
@@ -73,8 +82,7 @@ FORGE.MediaStore.prototype._boot = function()
 {
     this._register();
 
-    this._images = new FORGE.Map();
-    this._maxSize = 200; // can contains level 0 to 4
+    this._textures = new FORGE.Map();
 
     this._parseConfig(this._config);
 };
@@ -99,36 +107,58 @@ FORGE.MediaStore.prototype._parseConfig = function(config)
 };
 
 /**
+ * Create the key of an image.
+ *
+ * @method FORGE.MediaStore#_createKey
+ * @param {string} face - the face associated to this image
+ * @param {number=} level - the level of quality
+ * @param {number=} x - the x coordinate for position
+ * @param {number=} y - the y coordinate for position
+ * @return {string} returns the key for this image
+ * @private
+ */
+FORGE.MediaStore.prototype._createKey = function(face, level, x, y)
+{
+    var key = "";
+    key += typeof face !== "undefined" ? face + "-" : "";
+    key += typeof level !== "undefined" ? level  + "-" : "";
+    key += typeof x !== "undefined" ? x + "-" : "";
+    key += typeof y !== "undefined" ? y : "";
+
+    return key;
+};
+
+/**
  * Loads an Image from parameters, but doesn't add it to the map yet.
  *
  * @method FORGE.MediaStore#_load
+ * @param {string} key - the key of the image
  * @param {string} face - the face associated to this image
  * @param {number} level - the level of quality
  * @param {number} x - the x coordinate for position
  * @param {number} y - the y coordinate for position
  * @private
  */
-FORGE.MediaStore.prototype._load = function(face, level, x, y)
+FORGE.MediaStore.prototype._load = function(key, face, level, x, y)
 {
-    var key = "";
-    key += face;
-    key += "-" + level;
-    key += "-" + x;
-    key += "-" + y;
-
     var url = this._pattern;
-    url.replace(/{face}/, face);
-    url.replace(/{level}/, level.toString());
-    url.replace(/{x}/, x.toString());
-    url.replace(/{y}/, y.toString());
+    url = url.replace(/\{face\}/, face);
+    url = url.replace(/\{level\}/, level.toString());
+    url = url.replace(/\{x\}/, x.toString());
+    url = url.replace(/\{y\}/, y.toString());
 
     var config = {
-        key: key,
         url: url
     };
 
     var image = new FORGE.Image(this._viewer, config);
-    image.onLoadComplete.addOnce(this._onLoadComplete, this);
+
+    image.data = {
+        key: key,
+        level: level
+    };
+
+    image.onLoadComplete.add(this._onLoadComplete, this);
 };
 
 /**
@@ -140,13 +170,70 @@ FORGE.MediaStore.prototype._load = function(face, level, x, y)
  */
 FORGE.MediaStore.prototype._onLoadComplete = function(image)
 {
-    this._images.set(image.uid, image);
+    image = image.emitter;
+
+    var texture = new THREE.Texture();
+    texture.image = image.element;
+
+    var size = image.element.height * image.element.width;
+    this._size += size;
+
+    var mediaTexture = new FORGE.MediaTexture(texture, (image.data.level === 0), size);
+    this._textures.set(image.data.key, mediaTexture);
+
+    // destroy the image, it is no longer needed
+    image.destroy();
+
+    this._checkSize();
+};
+
+/**
+ * Check the current size of the store, and flush some texture if necessary.
+ *
+ * @method FORGE.MediaStore#_checkSize
+ * @private
+ */
+FORGE.MediaStore.prototype._checkSize = function()
+{
+    if (this._size < FORGE.MediaStore.MAX_SIZE)
+    {
+        return;
+    }
+
+    var entries = this._textures.entries(),
+        time = window.performance.now();
+
+    entries = FORGE.Utils.sortArrayByProperty(entries, "1.lastTime");
+
+    var force = false;
+
+    while (this._size > FORGE.MediaStore.MAX_SIZE)
+    {
+        // oldest are first
+        texture = entries.shift();
+
+        // if no  more entries (aka all texture are level 0) remove it anyway
+        if (typeof texture === "undefined")
+        {
+            entries = this._textures.entries();
+            entries = FORGE.Utils.sortArrayByProperty(entries, "1.lastTime");
+            force = true;
+        }
+
+        // but don't delete if it is locked
+        if (texture[1].locked !== true || force === true)
+        {
+            this._size -= texture[1].size;
+            texture[1].destroy();
+            this._textures.delete(texture[0]);
+        }
+    }
 };
 
 /**
  * Get an image from this store, given four parameters: the face associated to
  * this image, the level of quality and the x and y positions. It returns
- * either a {@link FORGE.Image} or null.
+ * either a {@link THREE.Texture} or null.
  *
  * The inner working is as follow: either the image is already loaded and
  * returned, or either the image is being loaded and nothing is returned yet.
@@ -158,25 +245,20 @@ FORGE.MediaStore.prototype._onLoadComplete = function(image)
  * @param {number} level - the level of quality
  * @param {number} x - the x coordinate for position
  * @param {number} y - the y coordinate for position
- * @return {?FORGE.Image} returns the image if present, else null
+ * @return {?THREE.Texture} returns the image if present, else null
  */
 FORGE.MediaStore.prototype.get = function(face, level, x, y)
 {
-    var key = "";
+    var key = this._createKey(face, level, x, y);
 
-    key += face;
-    key += "-" + level;
-    key += "-" + x;
-    key += "-" + y;
-
-    var res = /** @type {FORGE.Image} */ (this._images.get(key));
+    var res = /** @type {FORGE.MediaTexture} */ (this._textures.get(key));
 
     if (res !== undefined)
     {
-        return res;
+        return res.texture;
     }
 
-    this._load(face, level, x, y);
+    this._load(key, face, level, x, y);
 
     return null;
 };
@@ -190,6 +272,6 @@ FORGE.MediaStore.prototype.destroy = function()
 {
     this._viewer = null;
 
-    this._images.clear();
-    this._images = null;
+    this._textures.clear();
+    this._textures = null;
 };

--- a/src/media/MediaStore.js
+++ b/src/media/MediaStore.js
@@ -1,0 +1,195 @@
+/**
+ * This object stores a number of tiles used for multi resolution cases with
+ * tiles. It acts as a LRU map, as we can't store infinite amount of tiles.
+ * The number of tiles to store is (6 * 2^n)!, with n being the number of levels.
+ *
+ * There is an exception though: the level 0 of a multi resolution is always
+ * kept in the cache.
+ *
+ * @constructor FORGE.MediaStore
+ * @param {FORGE.Viewer} viewer - {@link FORGE.Viewer} reference
+ * @param {SceneMediaSourceConfig} config - the config given by a media to know
+ *                                          how to load each tile
+ * @extends {FORGE.BaseObject}
+ */
+FORGE.MediaStore = function(viewer, config)
+{
+    /**
+     * The viewer reference.
+     * @name FORGE.MediaStore#_viewer
+     * @type {FORGE.Viewer}
+     * @private
+     */
+    this._viewer = viewer;
+
+    /**
+     * Media source configuration
+     * @name FORGE.MediaStore#_config
+     * @type {SceneMediaSourceConfig}
+     * @private
+     */
+    this._config = config;
+
+    /**
+     * A map containing all {@link FORGE.Image}, with the key being constitued
+     * from the level, face, x and y properties defining the image
+     * @name FORGE.MediaStore#_images
+     * @type {?FORGE.Map}
+     * @private
+     */
+    this._images = null;
+
+    /**
+     * The maximum size of the store
+     * @name FORGE.MediaStore#_maxSize
+     * @type {number}
+     * @private
+     */
+    this._maxSize = 0;
+
+    /**
+     * The pattern to follow to laod the images
+     * @name FORGE.MediaStore#_pattern
+     * @type {string}
+     * @private
+     */
+    this._pattern = "";
+
+    FORGE.BaseObject.call(this, "MediaStore");
+
+    this._boot();
+};
+
+FORGE.MediaStore.prototype = Object.create(FORGE.BaseObject.prototype);
+FORGE.MediaStore.prototype.constructor = FORGE.MediaStore;
+
+/**
+ * Boot routine.
+ *
+ * @method FORGE.MediaStore#_boot
+ * @private
+ */
+FORGE.MediaStore.prototype._boot = function()
+{
+    this._register();
+
+    this._images = new FORGE.Map();
+    this._maxSize = 200; // can contains level 0 to 4
+
+    this._parseConfig(this._config);
+};
+
+/**
+ * Parse config routine.
+ *
+ * @method FORGE.MediaStore#_parseConfig
+ * @param {SceneMediaSourceConfig} config - the config of the media source
+ * @private
+ */
+FORGE.MediaStore.prototype._parseConfig = function(config)
+{
+    // a pattern should contains at least {f}, {l}, {x} or {y}
+    var re = /\{[lfxy]\}/;
+    if (typeof config.pattern !== "string" || config.pattern.match(re) === null)
+    {
+        throw "the pattern of the multi resolution media is wrong";
+    }
+
+    this._pattern = config.pattern;
+};
+
+/**
+ * Loads an Image from parameters, but doesn't add it to the map yet.
+ *
+ * @method FORGE.MediaStore#_load
+ * @param {string} face - the face associated to this image
+ * @param {number} level - the level of quality
+ * @param {number} x - the x coordinate for position
+ * @param {number} y - the y coordinate for position
+ * @private
+ */
+FORGE.MediaStore.prototype._load = function(face, level, x, y)
+{
+    var key = "";
+    key += face;
+    key += "-" + level;
+    key += "-" + x;
+    key += "-" + y;
+
+    var url = this._pattern;
+    url.replace(/{face}/, face);
+    url.replace(/{level}/, level.toString());
+    url.replace(/{x}/, x.toString());
+    url.replace(/{y}/, y.toString());
+
+    var config = {
+        key: key,
+        url: url
+    };
+
+    var image = new FORGE.Image(this._viewer, config);
+    image.onLoadComplete.addOnce(this._onLoadComplete, this);
+};
+
+/**
+ * Add the loaded image to the map.
+ *
+ * @method FORGE.MediaStore#_onLoadComplete
+ * @param {FORGE.Image} image - the loaded image
+ * @private
+ */
+FORGE.MediaStore.prototype._onLoadComplete = function(image)
+{
+    this._images.set(image.uid, image);
+};
+
+/**
+ * Get an image from this store, given four parameters: the face associated to
+ * this image, the level of quality and the x and y positions. It returns
+ * either a {@link FORGE.Image} or null.
+ *
+ * The inner working is as follow: either the image is already loaded and
+ * returned, or either the image is being loaded and nothing is returned yet.
+ * If the latter, the image is added to the map once it is completely loaded
+ * (the onLoadComplete event).
+ *
+ * @method FORGE.MediaStore#get
+ * @param {string} face - the face associated to this image
+ * @param {number} level - the level of quality
+ * @param {number} x - the x coordinate for position
+ * @param {number} y - the y coordinate for position
+ * @return {?FORGE.Image} returns the image if present, else null
+ */
+FORGE.MediaStore.prototype.get = function(face, level, x, y)
+{
+    var key = "";
+
+    key += face;
+    key += "-" + level;
+    key += "-" + x;
+    key += "-" + y;
+
+    var res = /** @type {FORGE.Image} */ (this._images.get(key));
+
+    if (res !== undefined)
+    {
+        return res;
+    }
+
+    this._load(face, level, x, y);
+
+    return null;
+};
+
+/**
+ * Destroy routine.
+ *
+ * @method FORGE.MediaStore#destroy
+ */
+FORGE.MediaStore.prototype.destroy = function()
+{
+    this._viewer = null;
+
+    this._images.clear();
+    this._images = null;
+};

--- a/src/media/MediaStore.js
+++ b/src/media/MediaStore.js
@@ -67,7 +67,7 @@ FORGE.MediaStore.prototype.constructor = FORGE.MediaStore;
  * The maximum size of texture at once. It is set at 30Mb, as we assume the
  * median size of a cache is 32Mb, and we keep 2Mb for other texture.
  * @name FORGE.MediaStore.MAX_SIZE
- * @type {string}
+ * @type {number}
  * @const
  */
 FORGE.MediaStore.MAX_SIZE = 31457280;
@@ -121,7 +121,7 @@ FORGE.MediaStore.prototype._createKey = function(face, level, x, y)
 {
     var key = "";
     key += typeof face !== "undefined" ? face + "-" : "";
-    key += typeof level !== "undefined" ? level  + "-" : "";
+    key += typeof level !== "undefined" ? level + "-" : "";
     key += typeof x !== "undefined" ? x + "-" : "";
     key += typeof y !== "undefined" ? y : "";
 
@@ -201,11 +201,11 @@ FORGE.MediaStore.prototype._checkSize = function()
     }
 
     var entries = this._textures.entries(),
-        time = window.performance.now();
+        time = window.performance.now(),
+        force = false,
+        texture;
 
     entries = FORGE.Utils.sortArrayByProperty(entries, "1.lastTime");
-
-    var force = false;
 
     while (this._size > FORGE.MediaStore.MAX_SIZE)
     {

--- a/src/media/MediaStore.js
+++ b/src/media/MediaStore.js
@@ -1,7 +1,7 @@
 /**
  * This object stores a number of tiles used for multi resolution cases with
  * tiles. It acts as a LRU map, as we can't store infinite amount of tiles.
- * The number of tiles to store is (6 * 4^n)!, with n being the number of levels.
+ * The number of tiles to store is Σ(6 * 4^n), with n being the number of levels.
  *
  * There is an exception though: the level 0 of a multi resolution is always
  * kept in the cache.
@@ -270,6 +270,8 @@ FORGE.MediaStore.prototype.get = function(face, level, x, y)
  */
 FORGE.MediaStore.prototype.destroy = function()
 {
+    this._unregister();
+
     this._viewer = null;
 
     this._textures.clear();

--- a/src/media/MediaTexture.js
+++ b/src/media/MediaTexture.js
@@ -1,0 +1,142 @@
+/**
+ * This object stores a THREE.Texture used for multi resolutions scene. It is
+ * simplier (in terms of memory to store this object as it is tinier than a
+ * FORGE.Image. It also remove the fact that we need to create a THREE.Texture
+ * in the renderer.
+ *
+ * @constructor FORGE.MediaTexture
+ * @param {THREE.Texture} texture - the THREE.Texture to store
+ * @param {boolean} locked - is the texture locked (i.e. it isn't deletable)
+ * @param {number} size - the size of the texture
+ */
+FORGE.MediaTexture = function(texture, locked, size)
+{
+    /**
+     * The texture
+     * @name FORGE.MediaTexture#_texture
+     * @type {THREE.Texture}
+     * @private
+     */
+    this._texture = texture;
+
+    /**
+     * Can the texture be deleted ? Otherwise it is locked, e.g. it is a level 0
+     * @name FORGE.MediaTexture#_locked
+     * @type {boolean}
+     * @private
+     */
+    this._locked = locked;
+
+    /**
+     * The size of the texture
+     * @name FORGE.MediaTexture#_size
+     * @type {number}
+     * @private
+     */
+    this._size = size;
+
+    /**
+     * The time the texture was last used
+     * @name FORGE.MediaTexture#_lastTime
+     * @type {number}
+     * @private
+     */
+    this._lastTime = window.performance.now();
+
+    /**
+     * The number of times the texture was used
+     * @name FORGE.MediaTexture#_count
+     * @type {number}
+     * @private
+     */
+    this._count = 0;
+};
+
+FORGE.MediaTexture.prototype.constructor = FORGE.MediaTexture;
+
+/**
+ * Destroy routine
+ * @method FORGE.MediaTexture#destroy
+ */
+FORGE.MediaTexture.prototype.destroy = function()
+{
+    this._texture = null;
+};
+
+/**
+ * Get the texture.
+ * @name  FORGE.MediaTexture#texture
+ * @type {string}
+ * @readonly
+ */
+Object.defineProperty(FORGE.MediaTexture.prototype, "texture",
+{
+    /** @this {FORGE.MediaTexture} */
+    get: function()
+    {
+        this._count++;
+        this._lastTime = window.performance.now();
+
+        return this._texture;
+    }
+});
+
+/**
+ * Is the texture locked ?
+ * @name  FORGE.MediaTexture#locked
+ * @type {boolean}
+ * @readonly
+ */
+Object.defineProperty(FORGE.MediaTexture.prototype, "locked",
+{
+    /** @this {FORGE.MediaTexture} */
+    get: function()
+    {
+        return this._locked;
+    }
+});
+
+/**
+ * Get the size of the texture
+ * @name  FORGE.MediaTexture#size
+ * @type {number}
+ * @readonly
+ */
+Object.defineProperty(FORGE.MediaTexture.prototype, "size",
+{
+    /** @this {FORGE.MediaTexture} */
+    get: function()
+    {
+        return this._size;
+    }
+});
+
+/**
+ * Get the last time when it was called.
+ * @name  FORGE.MediaTexture#lastTime
+ * @type {number}
+ * @readonly
+ */
+Object.defineProperty(FORGE.MediaTexture.prototype, "lastTime",
+{
+    /** @this {FORGE.MediaTexture} */
+    get: function()
+    {
+        return this._lastTime;
+    }
+});
+
+/**
+ * Get the number of times it was called.
+ * @name  FORGE.MediaTexture#count
+ * @type {number}
+ * @readonly
+ */
+Object.defineProperty(FORGE.MediaTexture.prototype, "count",
+{
+    /** @this {FORGE.MediaTexture} */
+    get: function()
+    {
+        return this._count;
+    }
+});

--- a/src/story/Scene.js
+++ b/src/story/Scene.js
@@ -448,7 +448,6 @@ FORGE.Scene.prototype.hasSoundSource = function()
     {
         return true;
     }
-
     return false;
 };
 
@@ -500,6 +499,9 @@ FORGE.Scene.prototype.destroy = function()
 
     this._description.destroy();
     this._description = null;
+
+    this._media.destroy();
+    this._media = null;
 
     if (this._onLoadStart !== null)
     {


### PR DESCRIPTION
Introduces a new class for multi resolution and assets management: `MediaStore`. When creating a media, the media isn't creating an `Image`, but instead a `MediaStore`, gettable from the store property of the media object.

A `get` method is available on the `MediaStore` (available itself through `viewer.story.scene.media.store`), with four parameters: the face, the level, the x and the y of the tile to get. It returns a THREE.Texture already loaded with the correct texture.

Concerning the size of the cache, we authorize for now 30Mo, which is arbitrary. Maybe in the future we can adapt this size given the system informations (but should be limited, so idk). Textures are flushed every time the max size is reached, with the oldest texture getting out first. 
There is an exception though:  level 0 textures never get flushed.

Don't merge before @ygilquin-gpsw added his approval on the returned objects by the store.

This is still marked as a WIP as I have maybe forgotten things to add.