### PR TITLE
Alps 833 - Error on the creation of a HotspotGeometry of type shape

### DIFF
--- a/src/hotspots/HotspotGeometry.js
+++ b/src/hotspots/HotspotGeometry.js
@@ -14,8 +14,34 @@ FORGE.HotspotGeometry.SHAPE = function(options)
 {
     options = options || {};
 
+    // clean the points given to remove any duplicate when points are following each other
+    if (Array.isArray(options.points))
+    {
+        options.points.push(options.points[0]);
+
+        var a, b, res = [];
+        for (var i = 0, ii = options.points.length - 1; i < ii; i++)
+        {
+            a = options.points[i];
+            b = options.points[i + 1];
+
+            if (a[0] !== b[0] || a[1] !== b[1])
+            {
+                res.push(a);
+            }
+        }
+
+        options.points = res;
+    }
+
+    if (options.points.length < 3)
+    {
+        console.warn("FORGE.HotspotGeometry.SHAPE: the points given to draw the shape should be a least 3");
+        options.points = null;
+    }
+
     //Default points array that is a square
-    if(Array.isArray(options.points) === false)
+    if (Array.isArray(options.points) === false)
     {
         options.points =
         [


### PR DESCRIPTION
Check the points given when creating a Shape as the geometry of a hotspot. For each point following each other, we check if they aren't the same. If there are less than three points, the Shape is the default one: a square.