### PR TITLE
Quick fix for gamepad unavailability

### DIFF
--- a/src/input/GamepadsManager.js
+++ b/src/input/GamepadsManager.js
@@ -54,8 +54,9 @@ FORGE.GamepadsManager.prototype.constructor = FORGE.GamepadsManager;
  */
 FORGE.GamepadsManager.prototype._boot = function()
 {
-    if (FORGE.Device.ie === true)
+    if (FORGE.Device.gamepad === false)
     {
+        this.warn("Gamepads are not available with your browser");
         return;
     }
 
@@ -128,6 +129,11 @@ FORGE.GamepadsManager.prototype._disconnect = function(index)
  */
 FORGE.GamepadsManager.prototype.update = function()
 {
+    if(this._gamepads === null)
+    {
+        return;
+    }
+
     var gamepad, gamepads = navigator.getGamepads();
 
     for (var i = 0, ii = gamepads.length; i < ii; i++)


### PR DESCRIPTION
Check if the gamepad method is defined on GamepadsManager boot then return from the update loop of the manager if the _gamepads array is still null