### PR TITLE
Bugfixes for 0.9.3

### DIFF
--- a/src/core/Viewer.js
+++ b/src/core/Viewer.js
@@ -669,7 +669,7 @@ FORGE.Viewer.prototype.pause = function(internal)
     this._paused = true;
 
     // Pause all media if autoPause is true
-    if (internal !== true || this._config.autoPause === true)
+    if (internal !== true || (this._config !== null && this._config.autoPause === true))
     {
         this._audio.pauseAll();
     }
@@ -697,7 +697,7 @@ FORGE.Viewer.prototype.resume = function(internal)
     this._paused = false;
 
     // Resume all media if autoResume is true
-    if (internal !== true || this._config.autoResume === true)
+    if (internal !== true || (this._config !== null && this._config.autoResume === true))
     {
         this._audio.resumeAll();
     }

--- a/src/director/Director.js
+++ b/src/director/Director.js
@@ -194,7 +194,7 @@ FORGE.Director.prototype._sceneLoadCompleteHandler = function()
             // React on loading/buffering event
             this._viewer.story.scene.media.displayObject.onWaiting.add(this._waitingHandler, this);
             this._viewer.story.scene.media.displayObject.onStalled.add(this._waitingHandler, this);
-            this._viewer.story.scene.media.displayObject.onSeeked.add(this._waitingHandler, this);
+            this._viewer.story.scene.media.displayObject.onSeeking.add(this._waitingHandler, this);
 
             // The director's cut begin again if video is looping
             this._viewer.story.scene.media.displayObject.onEnded.add(this._endedHandler, this);
@@ -285,8 +285,9 @@ FORGE.Director.prototype._waitingHandler = function()
     {
         this._viewer.story.scene.media.displayObject.onWaiting.remove(this._waitingHandler, this);
         this._viewer.story.scene.media.displayObject.onStalled.remove(this._waitingHandler, this);
-        this._viewer.story.scene.media.displayObject.onSeeked.remove(this._waitingHandler, this);
+        this._viewer.story.scene.media.displayObject.onSeeking.remove(this._waitingHandler, this);
         this._viewer.story.scene.media.displayObject.onPlaying.add(this._playingHandler, this);
+        this._viewer.story.scene.media.displayObject.onSeeked.add(this._playingHandler, this);
     }
     // for controllers
     this._viewer.controllers.onControlStart.remove(this._controlStartHandler, this);
@@ -316,9 +317,10 @@ FORGE.Director.prototype._playingHandler = function()
     if (this._viewer.story.scene.media.type === FORGE.MediaType.VIDEO)
     {
         this._viewer.story.scene.media.displayObject.onPlaying.remove(this._playingHandler, this);
+        this._viewer.story.scene.media.displayObject.onSeeked.remove(this._playingHandler, this);
         this._viewer.story.scene.media.displayObject.onWaiting.add(this._waitingHandler, this);
         this._viewer.story.scene.media.displayObject.onStalled.add(this._waitingHandler, this);
-        this._viewer.story.scene.media.displayObject.onSeeked.add(this._waitingHandler, this);
+        this._viewer.story.scene.media.displayObject.onSeeking.add(this._waitingHandler, this);
     }
     // for controllers
     this._viewer.controllers.onControlStart.add(this._controlStartHandler, this);

--- a/src/display/video/VideoDash.js
+++ b/src/display/video/VideoDash.js
@@ -305,6 +305,14 @@ FORGE.VideoDash = function(viewer, key, config, qualityMode)
     this._onVolumeChange = null;
 
     /**
+     * On seeking event dispatcher.
+     * @name  FORGE.VideoDash#_onSeeking
+     * @type {?FORGE.EventDispatcher}
+     * @private
+     */
+    this._onSeeking = null;
+
+    /**
      * On seeked event dispatcher.
      * @name  FORGE.VideoDash#_onSeeked
      * @type {?FORGE.EventDispatcher}
@@ -497,6 +505,14 @@ FORGE.VideoDash = function(viewer, key, config, qualityMode)
     this._onVolumeChangeBind = null;
 
     /**
+     * Event handler for current video seeking binded to this.
+     * @name FORGE.VideoDash#_onSeekingBind
+     * @type {Function}
+     * @private
+     */
+    this._onSeekingBind = null;
+
+    /**
      * Event handler for current video seeked binded to this.
      * @name FORGE.VideoDash#_onSeekedBind
      * @type {Function}
@@ -633,6 +649,7 @@ FORGE.VideoDash.prototype._boot = function()
     this._onPauseBind = this._onPauseHandler.bind(this);
     this._onTimeUpdateBind = this._onTimeUpdateHandler.bind(this);
     this._onVolumeChangeBind = this._onVolumeChangeHandler.bind(this);
+    this._onSeekingBind = this._onSeekingHandler.bind(this);
     this._onSeekedBind = this._onSeekedHandler.bind(this);
     this._onEndedBind = this._onEndedHandler.bind(this);
     this._onErrorBind = this._onErrorHandler.bind(this);
@@ -848,6 +865,7 @@ FORGE.VideoDash.prototype._installEvents = function()
     this._dashMediaPlayer.on(dashjs.MediaPlayer.events["PLAYBACK_METADATA_LOADED"], this._onLoadedMetaDataBind);
     this._dashMediaPlayer.on(dashjs.MediaPlayer.events["PLAYBACK_PAUSED"], this._onPauseBind);
     this._dashMediaPlayer.on(dashjs.MediaPlayer.events["PLAYBACK_PROGRESS"], this._onProgressBind);
+    this._dashMediaPlayer.on(dashjs.MediaPlayer.events["PLAYBACK_SEEKING"], this._onSeekingBind);
     this._dashMediaPlayer.on(dashjs.MediaPlayer.events["PLAYBACK_SEEKED"], this._onSeekedBind);
     this._dashMediaPlayer.on(dashjs.MediaPlayer.events["PLAYBACK_STARTED"], this._onPlayBind);
     this._dashMediaPlayer.on(dashjs.MediaPlayer.events["PLAYBACK_TIME_UPDATED"], this._onTimeUpdateBind);
@@ -880,6 +898,7 @@ FORGE.VideoDash.prototype._uninstallEvents = function()
     this._dashMediaPlayer.off(dashjs.MediaPlayer.events["PLAYBACK_METADATA_LOADED"], this._onLoadedMetaDataBind);
     this._dashMediaPlayer.off(dashjs.MediaPlayer.events["PLAYBACK_PAUSED"], this._onPauseBind);
     this._dashMediaPlayer.off(dashjs.MediaPlayer.events["PLAYBACK_PROGRESS"], this._onProgressBind);
+    this._dashMediaPlayer.off(dashjs.MediaPlayer.events["PLAYBACK_SEEKING"], this._onSeekingBind);
     this._dashMediaPlayer.off(dashjs.MediaPlayer.events["PLAYBACK_SEEKED"], this._onSeekedBind);
     this._dashMediaPlayer.off(dashjs.MediaPlayer.events["PLAYBACK_STARTED"], this._onPlayBind);
     this._dashMediaPlayer.off(dashjs.MediaPlayer.events["PLAYBACK_TIME_UPDATED"], this._onTimeUpdateBind);
@@ -1433,6 +1452,25 @@ FORGE.VideoDash.prototype._onVolumeChangeHandler = function(event)
 };
 
 /**
+ * Private event handler for seeking.
+ * @method  FORGE.VideoDash#_onSeekingHandler
+ * @private
+ * @param  {Event} event - The native video event.
+ */
+FORGE.VideoDash.prototype._onSeekingHandler = function(event)
+{
+    var element = this._video.element;
+    this.log("onSeeking [readyState: " + element.readyState + "]");
+
+    this._canPlay = false;
+
+    if (this._onSeeking !== null)
+    {
+        this._onSeeking.dispatch(event);
+    }
+};
+
+/**
  * Private event handler for seeked.
  * @method  FORGE.VideoDash#_onSeekedHandler
  * @private
@@ -1934,6 +1972,12 @@ FORGE.VideoDash.prototype.destroy = function()
         this._onVolumeChange = null;
     }
 
+    if (this._onSeeking !== null)
+    {
+        this._onSeeking.destroy();
+        this._onSeeking = null;
+    }
+
     if (this._onSeeked !== null)
     {
         this._onSeeked.destroy();
@@ -2011,6 +2055,7 @@ FORGE.VideoDash.prototype.destroy = function()
     this._onPauseBind = null;
     this._onTimeUpdateBind = null;
     this._onVolumeChangeBind = null;
+    this._onSeekingBind = null;
     this._onSeekedBind = null;
     this._onEndedBind = null;
     this._onErrorBind = null;
@@ -2699,6 +2744,26 @@ Object.defineProperty(FORGE.VideoDash.prototype, "onVolumeChange",
         }
 
         return this._onVolumeChange;
+    }
+});
+
+/**
+ * Get the "onSeeking" event {@link FORGE.EventDispatcher} of the video.
+ * @name FORGE.VideoDash#onSeeking
+ * @readonly
+ * @type {FORGE.EventDispatcher}
+ */
+Object.defineProperty(FORGE.VideoDash.prototype, "onSeeking",
+{
+    /** @this {FORGE.VideoDash} */
+    get: function()
+    {
+        if (this._onSeeking === null)
+        {
+            this._onSeeking = new FORGE.EventDispatcher(this);
+        }
+
+        return this._onSeeking;
     }
 });
 

--- a/src/display/video/VideoHTML5.js
+++ b/src/display/video/VideoHTML5.js
@@ -286,6 +286,14 @@ FORGE.VideoHTML5 = function(viewer, key, config, qualityMode, ambisonic)
     this._onVolumeChange = null;
 
     /**
+     * On seeking event dispatcher.
+     * @name  FORGE.VideoHTML5#_onSeeking
+     * @type {?FORGE.EventDispatcher}
+     * @private
+     */
+    this._onSeeking = null;
+
+    /**
      * On seeked event dispatcher.
      * @name  FORGE.VideoHTML5#_onSeeked
      * @type {?FORGE.EventDispatcher}
@@ -1623,6 +1631,7 @@ FORGE.VideoHTML5.prototype._installEvents = function(element)
     element.addEventListener("pause", this._onEventBind, false);
     element.addEventListener("timeupdate", this._onEventBind, false);
     element.addEventListener("volumechange", this._onEventBind, false);
+    element.addEventListener("seeking", this._onEventBind, false);
     element.addEventListener("seeked", this._onEventBind, false);
     element.addEventListener("ended", this._onEventBind, false);
     element.addEventListener("error", this._onEventBind, false);
@@ -1650,6 +1659,7 @@ FORGE.VideoHTML5.prototype._uninstallEvents = function(element)
     element.removeEventListener("pause", this._onEventBind, false);
     element.removeEventListener("timeupdate", this._onEventBind, false);
     element.removeEventListener("volumechange", this._onEventBind, false);
+    element.removeEventListener("seeking", this._onEventBind, false);
     element.removeEventListener("seeked", this._onEventBind, false);
     element.removeEventListener("ended", this._onEventBind, false);
     element.removeEventListener("error", this._onEventBind, false);
@@ -1771,6 +1781,16 @@ FORGE.VideoHTML5.prototype._onEventHandler = function(event)
             if (this._onVolumeChange !== null && element.readyState !== HTMLMediaElement.HAVE_NOTHING)
             {
                 this._onVolumeChange.dispatch(event);
+            }
+
+            break;
+
+        case "seeking":
+            this._canPlay = false;
+
+            if (this._onSeeking !== null)
+            {
+                this._onSeeking.dispatch(event);
             }
 
             break;
@@ -2106,6 +2126,12 @@ FORGE.VideoHTML5.prototype.destroy = function()
     {
         this._onVolumeChange.destroy();
         this._onVolumeChange = null;
+    }
+
+    if (this._onSeeking !== null)
+    {
+        this._onSeeking.destroy();
+        this._onSeeking = null;
     }
 
     if (this._onSeeked !== null)
@@ -2883,6 +2909,26 @@ Object.defineProperty(FORGE.VideoHTML5.prototype, "onVolumeChange",
         }
 
         return this._onVolumeChange;
+    }
+});
+
+/**
+ * Get the "onSeeking" event {@link FORGE.EventDispatcher} of the video.
+ * @name FORGE.VideoHTML5#onSeeking
+ * @readonly
+ * @type {FORGE.EventDispatcher}
+ */
+Object.defineProperty(FORGE.VideoHTML5.prototype, "onSeeking",
+{
+    /** @this {FORGE.VideoHTML5} */
+    get: function()
+    {
+        if (this._onSeeking === null)
+        {
+            this._onSeeking = new FORGE.EventDispatcher(this);
+        }
+
+        return this._onSeeking;
     }
 });
 


### PR DESCRIPTION
Two bug fixes for 0.9.3:

- fix the director's track on Firefox: it wasn't working due to some confusion between the `seeked` event of the video and the missing `seeking` one.
- fix crashing when opening in a new tab without focusing on it