### PR TITLE
Alps 1136 - Material opacity on hotspots

### DIFF
--- a/src/hotspots/HotspotMaterial.js
+++ b/src/hotspots/HotspotMaterial.js
@@ -563,21 +563,21 @@ FORGE.HotspotMaterial.prototype._createShaderMaterial = function()
     var vertexShader = FORGE.ShaderLib.parseIncludes(shader.vertexShader);
     var fragmentShader = FORGE.ShaderLib.parseIncludes(shader.fragmentShader);
 
+    // side is FrontSide, except if the geometry is a PLANE
+    var type = FORGE.UID.get(this._hotspotUid).geometry.type;
+    var side = (type === FORGE.HotspotGeometryType.PLANE) ? THREE.DoubleSide : THREE.FrontSide;
+
     this._material = new THREE.RawShaderMaterial(
     {
         fragmentShader: fragmentShader,
         vertexShader: vertexShader,
         uniforms: /** @type {FORGEUniform} */ (shader.uniforms),
-        side: THREE.DoubleSide,
+        side: side,
         name: "HotspotMaterial"
     });
 
-    if (this._texture !== null)
-    {
-        //Apply transparent parameter only if we have a texture.
-        this._material.transparent = this._transparent;
-        this._material.needsUpdate = true;
-    }
+    this._material.transparent = this._transparent;
+    this._material.needsUpdate = true;
 };
 
 FORGE.HotspotMaterial.prototype.updateShader = function()


### PR DESCRIPTION
There was a bug concerning the opacity of the hotspots, which was not really one in fact:

![screenshot 2017-06-14 15 36 05](https://user-images.githubusercontent.com/20340499/27134857-4643977e-5117-11e7-8007-baa724f889f8.png)

It seemed the opacity of hotspots was badly handled, but it was due to a misconfiguration of the testing case: the `transparent` property on the `material` of a hotspot was missing, thus set to `false` by default.

Meanwhile, doing this wasn't sufficient, as there were other display problems that were corrected:
- set the material side as FrontSide only for any hotspot, beside hotspots of type PLANE, which are still DoubleSide
- remove a condition on setting the transparency of a hotspot, reduced before to textured hotspot only

The resulting correct sample is as below:

![screenshot 2017-06-14 15 41 10](https://user-images.githubusercontent.com/20340499/27135078-e8854050-5117-11e7-87d3-14e71db8fa2a.png)
