### PR TITLE
Simplify the internal names management with the add of a prefix

### DIFF
--- a/src/3d/PickingDrawPass.js
+++ b/src/3d/PickingDrawPass.js
@@ -76,7 +76,7 @@ FORGE.PickingDrawPass.prototype._boot = function()
         vertexShader: FORGE.ShaderLib.parseIncludes(shader.vertexShader),
         uniforms: shader.uniforms,
         side: THREE.FrontSide,
-        name: "PickingMaterial"
+        name: FORGE.NAME+".PickingMaterial"
     });
 
     // Create picking render target
@@ -90,7 +90,7 @@ FORGE.PickingDrawPass.prototype._boot = function()
     var height = this._viewer.renderer.canvasResolution.height / this._scaling;
 
     this._target = new THREE.WebGLRenderTarget(width, height, rtParams);
-    this._target.name = "Picking RenderTarget";
+    this._target.name = FORGE.NAME+".PickingRenderTarget";
 };
 
 /**

--- a/src/FORGE.js
+++ b/src/FORGE.js
@@ -7,6 +7,14 @@
 var FORGE = FORGE || {};
 
 /**
+ * Name of ForgeJS.
+ * @name FORGE.NAME
+ * @type {string}
+ * @const
+ */
+FORGE.NAME = 'FORGEJS';
+
+/**
  * Version number of ForgeJS.
  * @name FORGE.VERSION
  * @type {string}

--- a/src/camera/Camera.js
+++ b/src/camera/Camera.js
@@ -416,7 +416,7 @@ FORGE.Camera.prototype._createMainCamera = function()
     {
         var aspect = this._viewer.renderer.displayResolution.ratio;
         this._main = new THREE.PerspectiveCamera(this._fov, aspect, FORGE.RenderManager.DEPTH_NEAR, 2 * FORGE.RenderManager.DEPTH_FAR);
-        this._main.name = "CameraMain";
+        this._main.name = FORGE.NAME+".CameraMain";
         this._main.matrixAutoUpdate = false;
     }
 };
@@ -436,7 +436,7 @@ FORGE.Camera.prototype._createFlatCamera = function()
             FORGE.RenderManager.DEPTH_NEAR,
             FORGE.RenderManager.DEPTH_FAR);
 
-        this._flat.name = "CameraFlat";
+        this._flat.name = FORGE.NAME+".CameraFlat";
         this._flat.matrixAutoUpdate = false;
     }
 };
@@ -449,13 +449,13 @@ FORGE.Camera.prototype._createFlatCamera = function()
 FORGE.Camera.prototype._createVRCameras = function()
 {
     this._left = this._main.clone();
-    this._left.name = "CameraLeft";
+    this._left.name = FORGE.NAME+".CameraLeft";
     this._left.layers.enable(1);
 
     this._left.add(this._gaze.object);
 
     this._right = this._main.clone();
-    this._right.name = "CameraRight";
+    this._right.name = FORGE.NAME+".CameraRight";
     this._right.layers.enable(2);
 };
 

--- a/src/camera/CameraGaze.js
+++ b/src/camera/CameraGaze.js
@@ -81,7 +81,7 @@ FORGE.CameraGaze.prototype._boot = function()
     this._timer = this._viewer.clock.create(false);
 
     this._object = new THREE.Object3D();
-    this._object.name = "CameraGaze";
+    this._object.name = FORGE.NAME+".CameraGaze";
     this._object.position.z = -2;
 
     this._createCursor();
@@ -128,7 +128,7 @@ FORGE.CameraGaze.prototype._createCursor = function()
     });
 
     var ring = new THREE.Mesh(this._createRingGeometry(this._config.cursor.innerRadius, this._config.cursor.outerRadius), material);
-    ring.name = "cursor";
+    ring.name = FORGE.NAME+".GazeCursor";
 
     this._object.add(ring);
 };
@@ -143,7 +143,7 @@ FORGE.CameraGaze.prototype._updateProgressRing = function(progress)
 {
     this._progress = progress;
 
-    this._destroyRing("progress");
+    this._destroyRing(FORGE.NAME+".GazeProgress");
 
     this._createProgress();
 };
@@ -166,7 +166,7 @@ FORGE.CameraGaze.prototype._createProgress = function()
     var thetaLength = (this._progress / 100) * FORGE.Math.TWOPI;
 
     var ring = new THREE.Mesh(this._createRingGeometry(this._config.progress.innerRadius, this._config.progress.outerRadius, 32, 1, (Math.PI / 2), thetaLength), material);
-    ring.name = "progress";
+    ring.name = FORGE.NAME+".GazeProgress";
     ring.rotateY(Math.PI);
 
     this._object.add(ring);
@@ -220,8 +220,8 @@ FORGE.CameraGaze.prototype.load = function(config)
 {
     this._config = config;
 
-    this._destroyRing("progress");
-    this._destroyRing("cursor");
+    this._destroyRing(FORGE.NAME+".GazeProgress");
+    this._destroyRing(FORGE.NAME+".GazeCursor");
 
     this._createCursor();
 

--- a/src/hotspots/Hotspot3D.js
+++ b/src/hotspots/Hotspot3D.js
@@ -154,7 +154,7 @@ FORGE.Hotspot3D.prototype._parseConfig = function(config)
     this._register();
 
     // Set the mesh name
-    this._mesh.name = "mesh-" + this._uid;
+    this._mesh.name = FORGE.NAME+".mesh-" + this._uid;
     this._mesh.userData = config;
 
     this._name = (typeof config.name === "string") ? config.name : "";
@@ -199,11 +199,11 @@ FORGE.Hotspot3D.prototype._onBeforeRender = function(renderer, scene, camera, ge
     this._viewer.renderer.view.current.updateUniforms(material.uniforms);
 
     // Check what is the current render pass looking at the material: Hotspot or Picking Material
-    if (material.name === "HotspotMaterial")
+    if (material.name === FORGE.NAME+".HotspotMaterial")
     {
         this._material.update();
     }
-    else if (material.name === "PickingMaterial")
+    else if (material.name === FORGE.NAME+"PickingMaterial")
     {
         // As picking material is the same for all spots renderer in this pass, material uniforms won't be refreshed
         // Setting material.uniforms.tColor value will be useless, set direct value by acceding program uniforms map

--- a/src/hotspots/HotspotMaterial.js
+++ b/src/hotspots/HotspotMaterial.js
@@ -1,6 +1,6 @@
 /**
  * Hotspot material handles the parse of the material config and the loading of the needed ressource.<br>
- * In the end it provides a THREE.MeshBasicMaterial when the ressources are loaded.
+ * In the end it provides a THREE.RawShaderMaterial when the ressources are loaded.
  *
  * @constructor FORGE.HotspotMaterial
  * @param {FORGE.Viewer} viewer - The viewer reference.
@@ -531,7 +531,7 @@ FORGE.HotspotMaterial.prototype._setupComplete = function()
 };
 
 /**
- * Create the THREE.MeshBasicMaterial that will be used on a THREE.Mesh
+ * Create the THREE.RawShaderMaterial that will be used on a THREE.Mesh
  * @method FORGE.HotspotMaterial#_createShaderMaterial
  * @private
  */
@@ -573,7 +573,7 @@ FORGE.HotspotMaterial.prototype._createShaderMaterial = function()
         vertexShader: vertexShader,
         uniforms: /** @type {FORGEUniform} */ (shader.uniforms),
         side: side,
-        name: "HotspotMaterial"
+        name: FORGE.NAME+".HotspotMaterial"
     });
 
     this._material.transparent = this._transparent;
@@ -743,10 +743,10 @@ Object.defineProperty(FORGE.HotspotMaterial.prototype, "texture",
 });
 
 /**
- * Get the THREE.MeshBasicMaterial used for this hotspot material.
+ * Get the THREE.RawShaderMaterial used for this hotspot material.
  * @name FORGE.HotspotMaterial#material
  * @readonly
- * @type {THREE.MeshBasicMaterial}
+ * @type {THREE.RawShaderMaterial}
  */
 Object.defineProperty(FORGE.HotspotMaterial.prototype, "material",
 {

--- a/src/render/RenderPipeline.js
+++ b/src/render/RenderPipeline.js
@@ -459,7 +459,7 @@ FORGE.RenderPipeline.prototype._setupDefaultBackground = function()
     context.fillRect(0, 0, canvas.width, canvas.height);
 
     var defaultTexture = new THREE.TextureLoader().load(canvas.toDataURL());
-    defaultTexture.name = "forge-default-texture";
+    defaultTexture.name = FORGE.NAME+".default-texture";
 
     this.addBackground(defaultTexture, null, 0);
 };

--- a/src/render/background/BackgroundMeshRenderer.js
+++ b/src/render/background/BackgroundMeshRenderer.js
@@ -528,7 +528,7 @@ FORGE.BackgroundMeshRenderer.prototype._updateInternals = function()
         fragmentShader: fragmentShader,
         vertexShader: vertexShader,
         uniforms: /** @type {FORGEUniform} */ (shader.uniforms),
-        name: "BackgroundMeshMaterial",
+        name: FORGE.NAME+".BackgroundMeshMaterial",
         transparent: true,
         side: THREE.BackSide
     });

--- a/src/render/postProcessing/AdditionPass.js
+++ b/src/render/postProcessing/AdditionPass.js
@@ -36,7 +36,7 @@ FORGE.AdditionPass = function(composer)
         vertexShader: vertexShader,
         uniforms: uniforms,
         side: THREE.FrontSide,
-        name: "FORGE.AdditionPassMaterial"
+        name: FORGE.NAME+".AdditionPassMaterial"
     });
 
     FORGE.ShaderPass.call(this, "", "Addition", this._material, "tTexture");


### PR DESCRIPTION
Add FORGE.NAME property as "FORGEJS" to prefix internal names.