### PR TITLE
Alps 1296 - Share current Camera & View parameters

### DIFF
--- a/src/system/History.js
+++ b/src/system/History.js
@@ -222,34 +222,15 @@ FORGE.History.prototype.generateHash = function(scene, keep)
     {
         var hash = window.location.hash;
 
-        // result for normal URL querystring (&uid=name&yaw=0&pitch=0&roll=0&fov=0&view=rectilinear)
-        var re = /(?:#|&)([\w\-]+)=([\w\-.]+)/g;
+        // result for normal URL querystring
+        var re = /[&#]([^&]+)/g;
         var rr;
         while ((rr = re.exec(hash)) !== null)
         {
-            if (rr[1] !== "uid")
+            if (rr[1].substr(0, 3) !== "uid" && rr[1] !== scene.slug)
             {
-                result += "&" + rr[1] + "=" + rr[2];
+                result += "&" + rr[1];
             }
-        }
-
-        // result for specific camera and view short URL support (&y0p0r0f0vrectilinear)
-        var reShort = /&?([0-9\-.]+|rectilinear|gopro|flat)(y|p|r|f|v)\,?/gi;
-        var activeShort = false;
-        while ((rr = reShort.exec(hash)) !== null)
-        {
-            if (activeShort === false && result.slice(-1) !== "&")
-            {
-                result += "&";
-                activeShort = true;
-            }
-            result += rr[1] + rr[2] + ',';
-        }
-
-        if (result.substr(-1) === ",")
-        {
-            // remove last comma
-            result = result.slice(0, -1);
         }
     }
 

--- a/src/system/History.js
+++ b/src/system/History.js
@@ -220,18 +220,30 @@ FORGE.History.prototype.generateHash = function(scene, keep)
     // Keep others parameters
     if(keep !== false)
     {
-        var re = /(?:#|&)([\w\-]+)=([\w\-.]+)/g;
         var hash = window.location.hash;
-        var rr = re.exec(hash);
 
-        while (rr !== null)
+        // result for normal URL querystring (&yaw=0&pitch=0&roll=0&fov=0&view=rectilinear)
+        var re = /(?:#|&)([\w\-]+)=([\w\-.]+)/g;
+        var rr;
+        while ((rr = re.exec(hash)) !== null)
         {
             if (rr[1] !== "uid")
             {
                 result += "&" + rr[1] + "=" + rr[2];
             }
+        }
 
-            rr = re.exec(hash);
+        // result for Share plugin short URL support (&y0p0r0f0vrectilinear)
+        var reShort = /&?(y|p|r|f|v)([0-9\-.]+|rectilinear|gopro|flat)/gi;
+        var activeShort = false;
+        while ((rr = reShort.exec(hash)) !== null)
+        {
+            if (activeShort === false && result.slice(-1) !== "&")
+            {
+                result += "&";
+                activeShort = true;
+            }
+            result += rr[1] + rr[2];
         }
     }
 

--- a/src/system/History.js
+++ b/src/system/History.js
@@ -206,7 +206,7 @@ FORGE.History.prototype._isStateValid = function(state)
 };
 
 /**
- * Generate a hash for the curretn scene with the i18n slug name and the scene uid.
+ * Generate a hash for the current scene with the i18n slug name and the scene uid.
  * @method FORGE.History#generateHash
  * @param  {FORGE.Scene|Object} scene - The scene for which you want to generate a hash.
  * @param {boolean} [keep=true] - Do we have to keep the existing URL parameters.
@@ -220,7 +220,7 @@ FORGE.History.prototype.generateHash = function(scene, keep)
     // Keep others parameters
     if(keep !== false)
     {
-         var re = /(?:#|&)(\w+)=(\w+)/g;
+        var re = /(?:#|&)([\w\-]+)=([\w\-.]+)/g;
         var hash = window.location.hash;
         var rr = re.exec(hash);
 

--- a/src/system/History.js
+++ b/src/system/History.js
@@ -139,11 +139,11 @@ FORGE.History.prototype._addState = function()
 
     if (currentState === null)
     {
-        window.history.replaceState(newState, scene.name, this._generateHash(scene));
+        window.history.replaceState(newState, scene.name, this.generateHash(scene));
     }
     else if (currentState.scene.uid !== newState.scene.uid)
     {
-        window.history.pushState(newState, scene.name, this._generateHash(scene));
+        window.history.pushState(newState, scene.name, this.generateHash(scene));
     }
 };
 
@@ -162,36 +162,8 @@ FORGE.History.prototype._updateState = function()
     {
         var scene = FORGE.UID.get(currentState.scene.uid);
         currentState.locale = this._viewer.i18n.locale;
-        window.history.replaceState(currentState, scene.name, this._generateHash( /** @type {FORGE.Scene} */ (scene)));
+        window.history.replaceState(currentState, scene.name, this.generateHash( /** @type {FORGE.Scene} */ (scene)));
     }
-};
-
-/**
- * Generate a hash for the curretn scene with the i18n slug name and the scene uid.
- * @param  {FORGE.Scene|Object} scene - The scene for which you want to generate a hash.
- * @return {string} The generated hash.
- * @private
- */
-FORGE.History.prototype._generateHash = function(scene)
-{
-    // Search for other parameters in URL, beside the UID
-    var re = /(?:#|&)(\w+)=(\w+)/g;
-    var hash = window.location.hash;
-    var rr = re.exec(hash);
-    var result = "";
-
-    // Keep others parameters
-    while (rr !== null)
-    {
-        if (rr[1] !== "uid")
-        {
-            result += "&" + rr[1] + "=" + rr[2];
-        }
-
-        rr = re.exec(hash);
-    }
-
-    return "#" + scene.slug + "&uid=" + scene.uid + result;
 };
 
 /**
@@ -231,6 +203,39 @@ FORGE.History.prototype._isStateValid = function(state)
     var sceneValid = (typeof state.scene !== "undefined" && typeof state.scene.uid === "string");
 
     return (viewerValid === true && sceneValid === true);
+};
+
+/**
+ * Generate a hash for the curretn scene with the i18n slug name and the scene uid.
+ * @method FORGE.History#generateHash
+ * @param  {FORGE.Scene|Object} scene - The scene for which you want to generate a hash.
+ * @param {boolean} [keep=true] - Do we have to keep the existing URL parameters.
+ * @return {string} The generated hash.
+ */
+FORGE.History.prototype.generateHash = function(scene, keep)
+{
+    // Search for other parameters in URL, beside the UID
+    var result = "";
+
+    // Keep others parameters
+    if(keep !== false)
+    {
+         var re = /(?:#|&)(\w+)=(\w+)/g;
+        var hash = window.location.hash;
+        var rr = re.exec(hash);
+
+        while (rr !== null)
+        {
+            if (rr[1] !== "uid")
+            {
+                result += "&" + rr[1] + "=" + rr[2];
+            }
+
+            rr = re.exec(hash);
+        }
+    }
+
+    return "#" + scene.slug + "&uid=" + scene.uid + result;
 };
 
 /**

--- a/src/system/History.js
+++ b/src/system/History.js
@@ -222,7 +222,7 @@ FORGE.History.prototype.generateHash = function(scene, keep)
     {
         var hash = window.location.hash;
 
-        // result for normal URL querystring (&yaw=0&pitch=0&roll=0&fov=0&view=rectilinear)
+        // result for normal URL querystring (&uid=name&yaw=0&pitch=0&roll=0&fov=0&view=rectilinear)
         var re = /(?:#|&)([\w\-]+)=([\w\-.]+)/g;
         var rr;
         while ((rr = re.exec(hash)) !== null)
@@ -233,8 +233,8 @@ FORGE.History.prototype.generateHash = function(scene, keep)
             }
         }
 
-        // result for Share plugin short URL support (&y0p0r0f0vrectilinear)
-        var reShort = /&?(y|p|r|f|v)([0-9\-.]+|rectilinear|gopro|flat)/gi;
+        // result for specific camera and view short URL support (&y0p0r0f0vrectilinear)
+        var reShort = /&?([0-9\-.]+|rectilinear|gopro|flat)(y|p|r|f|v)\,?/gi;
         var activeShort = false;
         while ((rr = reShort.exec(hash)) !== null)
         {
@@ -243,7 +243,13 @@ FORGE.History.prototype.generateHash = function(scene, keep)
                 result += "&";
                 activeShort = true;
             }
-            result += rr[1] + rr[2];
+            result += rr[1] + rr[2] + ',';
+        }
+
+        if (result.substr(-1) === ",")
+        {
+            // remove last comma
+            result = result.slice(0, -1);
         }
     }
 

--- a/src/utils/URL.js
+++ b/src/utils/URL.js
@@ -136,8 +136,6 @@ FORGE.URL.parse = function(url)
     return result;
 };
 
-
-
 /**
  * Check if a given url exists.
  * Beware of cross domain, work only on the same domain.
@@ -320,7 +318,7 @@ Object.defineProperty(FORGE.URL.prototype, "hash",
  * Get the hash parameters of the URL.
  * @name FORGE.URL#hashParameters
  * @readonly
- * @type {string}
+ * @type {Object}
  */
 Object.defineProperty(FORGE.URL.prototype, "hashParameters",
 {


### PR DESCRIPTION
Add short URL support for camera & view parameters into the generateHash method of History.

Short format sample : `&-32.02y,6.03p,0.00r,90.00f,rectilinearv` which is equivalent to `&yaw=-32.02&pitch=6.03&roll=0.00&fov=90.00&view=rectilinear`
