### PR TITLE
ALPS-1815 - startTime not respected

### DIFF
--- a/src/story/Story.js
+++ b/src/story/Story.js
@@ -378,7 +378,7 @@ FORGE.Story.prototype._sceneLoadRequestHandler = function(event)
 {
     var previousScene = this.scene;
     var nextScene = event.emitter;
-    var time = 0;
+    var time = NaN;
 
     //Unload the previous scene
     if(previousScene !== null)


### PR DESCRIPTION
Fix the startTime of a media not taken into account: medias were always starting at 0s, unless it was synced with another media.