### PR TITLE
Avoid the update of the view when the view is under destroy status

### DIFF
--- a/src/render/view/ViewFlat.js
+++ b/src/render/view/ViewFlat.js
@@ -60,44 +60,47 @@ FORGE.ViewFlat.prototype._boot = function()
  */
 FORGE.ViewFlat.prototype._updateViewParams = function()
 {
-    var vfov = FORGE.Math.degToRad(this._viewer.camera.fov);
-
-    // When repeat is ON, set yaw and pitch min and max depending on
-    // texture and screen ratios
-
-    if (this._viewer.renderer.backgroundRenderer instanceof FORGE.BackgroundShaderRenderer)
+    if (this._viewer !== null)
     {
-        if (this._options.repeatX === false)
+        // When repeat is ON, set yaw and pitch min and max depending on
+        // texture and screen ratios
+
+        if (this._viewer.renderer.backgroundRenderer instanceof FORGE.BackgroundShaderRenderer)
         {
-            var hfov = vfov * this._viewer.renderer.displayResolution.ratio;
-            var texRatio = this._viewer.renderer.backgroundRenderer.textureSize.ratio;
-            this._yawMax = Math.min(360, Math.max(0, (Math.PI * texRatio - hfov) * 0.5)); // image
-            this._yawMin = -this._yawMax;
+            var vfov = FORGE.Math.degToRad(this._viewer.camera.fov);
+
+            if (this._options.repeatX === false)
+            {
+                var hfov = vfov * this._viewer.renderer.displayResolution.ratio;
+                var texRatio = this._viewer.renderer.backgroundRenderer.textureSize.ratio;
+                this._yawMax = Math.min(360, Math.max(0, (Math.PI * texRatio - hfov) * 0.5)); // image
+                this._yawMin = -this._yawMax;
+            }
+            else
+            {
+                this._yawMin = FORGE.Math.degToRad(-360);
+                this._yawMax = FORGE.Math.degToRad(360);
+            }
+
+            if (this._options.repeatY === false)
+            {
+                this._pitchMax = 0.5 * Math.max(0, Math.PI - vfov);
+                this._pitchMin = -this._pitchMax;
+            }
+            else
+            {
+                this._pitchMin = FORGE.Math.degToRad(-180);
+                this._pitchMax = FORGE.Math.degToRad(180);
+            }
         }
+
+        // Mesh rendering in flat view is limited around -+ 20 degrees
         else
         {
-            this._yawMin = FORGE.Math.degToRad(-360);
-            this._yawMax = FORGE.Math.degToRad(360);
-        }
-
-        if (this._options.repeatY === false)
-        {
-            this._pitchMax = 0.5 * Math.max(0, Math.PI - vfov);
+            this._yawMax = this._pitchMax = FORGE.Math.degToRad(20);
+            this._yawMin = -this._yawMax;
             this._pitchMin = -this._pitchMax;
         }
-        else
-        {
-            this._pitchMin = FORGE.Math.degToRad(-180);
-            this._pitchMax = FORGE.Math.degToRad(180);
-        }
-    }
-
-    // Mesh rendering in flat view is limited around -+ 20 degrees
-    else
-    {
-        this._yawMax = this._pitchMax = FORGE.Math.degToRad(20);
-        this._yawMin = -this._yawMax;
-        this._pitchMin = -this._pitchMax;
     }
 };
 

--- a/src/render/view/ViewGoPro.js
+++ b/src/render/view/ViewGoPro.js
@@ -48,35 +48,38 @@ FORGE.ViewGoPro.prototype._boot = function()
  */
 FORGE.ViewGoPro.prototype._updateViewParams = function()
 {
-    var projFovLow = 90;
-    var projFovHigh = 180;
-    var distance = 0;
-
-    var fov = FORGE.Math.clamp(this._viewer.camera.fov, this._viewer.camera.fovMin, this._viewer.camera.fovMax);
-
-    var fn = 0;
-
-    if (fov < projFovLow)
+    if (this._viewer !== null)
     {
-        distance = 0;
-        fn = 0;
-    }
-    else if (fov > projFovHigh)
-    {
-        distance = 1;
-        fn = 1;
-    }
-    else
-    {
-        // Apply sinus in out interpolation to smooth the transition
-        fn = (fov - projFovLow) / (projFovHigh - projFovLow);
-        distance = 0.5 * (1.0 + Math.sin(Math.PI / 2.0 * (2.0 * fn - 1)));
-    }
+        var projFovLow = 90;
+        var projFovHigh = 180;
+        var distance = 0;
 
-    this._projectionDistance = distance;
+        var fov = FORGE.Math.clamp(this._viewer.camera.fov, this._viewer.camera.fovMin, this._viewer.camera.fovMax);
 
-    var fovRad = 0.5 * FORGE.Math.degToRad(fov);
-    this._projectionScale = (distance + 1) * Math.sin(fovRad) / (distance + Math.cos(fovRad));
+        var fn = 0;
+
+        if (fov < projFovLow)
+        {
+            distance = 0;
+            fn = 0;
+        }
+        else if (fov > projFovHigh)
+        {
+            distance = 1;
+            fn = 1;
+        }
+        else
+        {
+            // Apply sinus in out interpolation to smooth the transition
+            fn = (fov - projFovLow) / (projFovHigh - projFovLow);
+            distance = 0.5 * (1.0 + Math.sin(Math.PI / 2.0 * (2.0 * fn - 1)));
+        }
+
+        this._projectionDistance = distance;
+
+        var fovRad = 0.5 * FORGE.Math.degToRad(fov);
+        this._projectionScale = (distance + 1) * Math.sin(fovRad) / (distance + Math.cos(fovRad));
+    }
 };
 
 /**

--- a/src/render/view/ViewRectilinear.js
+++ b/src/render/view/ViewRectilinear.js
@@ -49,9 +49,12 @@ FORGE.ViewRectilinear.prototype._boot = function()
  */
 FORGE.ViewRectilinear.prototype._updateViewParams = function()
 {
-    var fov = FORGE.Math.clamp(this._viewer.camera.fov, this._viewer.camera.fovMin, this._viewer.camera.fovMax);
+    if (this._viewer !== null)
+    {
+        var fov = FORGE.Math.clamp(this._viewer.camera.fov, this._viewer.camera.fovMin, this._viewer.camera.fovMax);
 
-    this._projectionScale = Math.tan(FORGE.Math.degToRad(fov / 2));
+        this._projectionScale = Math.tan(FORGE.Math.degToRad(fov / 2));
+    }
 };
 
 /**


### PR DESCRIPTION
Current status: if the current view is destroyed the updateViewParams method can be called from event with a nullified viewer. 