### PR TITLE
ALPS-700 - Omnitone crash

### DIFF
--- a/externs/lib/omnitone.ext.js
+++ b/externs/lib/omnitone.ext.js
@@ -57,3 +57,57 @@ FOADecoder.prototype.initialize = function() {};
  * @const
  */
 Omnitone.FOADecoder = FOADecoder;
+
+/**
+ * Create a singleton FOARenderer instance.
+ * @param {AudioContext} context - Associated AudioContext.
+ * @param {FOARendererOptions} options - Options for FOA decoder.
+ * @return {FOARenderer}
+ */
+Omnitone.createFOARenderer = function (context, options) {};
+
+/**
+ * @typedef {{channelMap:(Array|undefined), hrirPathList:(Array|undefined), renderingMode:(string|undefined)}}
+ * @name FOARendererOptions
+ * @property {Array} channelMap - Custom channel routing map.
+ * @property {Array} hrirPathList - A list of paths to HRIR files.
+ * @property {RenderingMode} renderingMode - Rendering mode.
+ */
+var FOARendererOptions;
+
+/**
+ * Omnitone FOA renderer class. Uses the optimized convolution technique.
+ * @constructor
+ * @param {AudioContext} context - Associated AudioContext.
+ * @param {FOARendererOptions} options
+ * @return {!FOARenderer}
+ */
+function FOARenderer(context, options) {};
+
+/**
+ * @const
+ */
+Omnitone.FOARenderer = FOARenderer;
+/**
+ * @param  {Object} cameraMatrix - The Matrix4 object of the Three.js camera.
+ */
+FOARenderer.prototype.setRotationMatrixFromCamera = function(cameraMatrix) {};
+
+/**
+ * @param {string} mode - Decoding mode.
+ * When the mode is 'bypass' the decoder is disabled and bypass the input stream to the output.
+ * Setting the mode to 'ambisonic' activates the decoder.
+ * When the mode is 'off', all the processing is completely turned off saving the CPU power.
+ */
+FOARenderer.prototype.setMode = function(mode) {};
+
+/**
+ *
+ */
+FOARenderer.prototype.initialize = function() {};
+
+/** @type {GainNode} */
+FOARenderer.prototype.input;
+
+/** @type {GainNode} */
+FOARenderer.prototype.output;

--- a/src/audio/Sound.js
+++ b/src/audio/Sound.js
@@ -452,11 +452,15 @@ FORGE.Sound.prototype._boot = function()
         this._gainNode.gain.value = this._volume * this._viewer.audio.volume;
         this._gainNode.connect(this._inputNode);
     }
+
+    var loaded = false;
     if (this._viewer.audio.useAudioTag === true || this._isAmbisonic() === true)
     {
         if (this._viewer.cache.has(FORGE.Cache.types.SOUND, this._key) === true)
         {
-            this._loadComplete(this._viewer.cache.get(FORGE.Cache.types.SOUND, this._key));
+            // wait long enough so that a frame has passed (here at 24fps)
+            window.setTimeout(this._loadComplete.bind(this, this._viewer.cache.get(FORGE.Cache.types.SOUND, this._key)), 40);
+            loaded = true;
         }
 
         //Listen to the main volume change to adapt the sound volume accordingly.
@@ -467,7 +471,10 @@ FORGE.Sound.prototype._boot = function()
 
     if (this._url !== "")
     {
-        this._viewer.load.sound(this._key, this._url, this._loadComplete, this, this._isAmbisonic());
+        if (loaded === false)
+        {
+            this._viewer.load.sound(this._key, this._url, this._loadComplete, this, this._isAmbisonic());
+        }
 
         if (this._onLoadStart !== null)
         {
@@ -490,6 +497,11 @@ FORGE.Sound.prototype._loadComplete = function(file)
     if(this._alive === false)
     {
         return;
+    }
+
+    if (this._isAmbisonic() === true)
+    {
+        file.data = file.data.cloneNode(true);
     }
 
     this._soundFile = file;


### PR DESCRIPTION
When in a story with multiple scenes using omnitone/ambisonic sounds the library is initialized at each scene on the first time we visit them and if we revisit them again it throws an error.

This PR fixes this problem.