### PR TITLE
BackgroundRenderer Type fix

### DIFF
--- a/src/render/RenderManager.js
+++ b/src/render/RenderManager.js
@@ -741,26 +741,19 @@ FORGE.RenderManager.prototype._setBackgroundRendererType = function(vrEnabled)
     {
         this._backgroundRendererType = FORGE.BackgroundType.MESH;
     }
-    else if (typeof mediaConfig.source === "undefined" ||
-        mediaConfig.source.format === FORGE.MediaFormat.CUBE ||
-        mediaConfig.source.format === FORGE.MediaFormat.FLAT ||
-        typeof mediaConfig.source === "undefined" ||
-        typeof mediaConfig.source.format === "undefined")
+    else if (typeof mediaConfig.source !== "undefined")
     {
-        if (typeof mediaConfig.source.levels !== "undefined")
+        if (typeof mediaConfig.source.levels !== "undefined" && media.type === FORGE.MediaType.IMAGE)
         {
             this._backgroundRendererType = FORGE.BackgroundType.PYRAMID;
         }
+        else if (mediaConfig.source.format === FORGE.MediaFormat.CUBE)
+        {
+            this._backgroundRendererType = FORGE.BackgroundType.MESH;
+        }
         else
         {
-            if (this._viewManager.current.type === FORGE.ViewType.FLAT)
-            {
-                this._backgroundRendererType = FORGE.BackgroundType.SHADER;
-            }
-            else
-            {
-                this._backgroundRendererType = FORGE.BackgroundType.MESH;
-            }
+            this._backgroundRendererType = FORGE.BackgroundType.SHADER;
         }
     }
     else


### PR DESCRIPTION
Rework parse of background renderer type, hence fix a bug when two multiquality video were following each other.

Fix the problem in https://github.com/gopro/forgejs-samples/pull/44/