### PR TITLE
Fix the hotspot test

### DIFF
--- a/test/hotspots/HotspotManager.spec.js
+++ b/test/hotspots/HotspotManager.spec.js
@@ -7,7 +7,7 @@ describe("HotspotManager", function() {
 
     beforeAll(function(done) {
         this.viewer = new FORGE.Viewer("container", {});
-        this.viewer.onReady.add(done, this);
+        this.viewer.onConfigLoadComplete.add(done, this);
     });
 
     afterAll(function() {


### PR DESCRIPTION
Fix the hotspot test, caused by a forgotten update of `viewer.onReady` to `viewer.onConfigLoadComplete`.