### PR TITLE
Multiresolution stabilization

### DIFF
--- a/externs/lib/three.ext.js
+++ b/externs/lib/three.ext.js
@@ -1201,6 +1201,11 @@ THREE.Raycaster.prototype.intersectObjects = function(arg1) {};
 THREE.Scene = function() {};
 
 /**
+ * @param {THREE.Object3D} arg1
+ */
+THREE.Scene.prototype.getObjectByName = function(arg1) {};
+
+/**
  * @constructor
  * @param {(Element|HTMLElement)=} arg1
  * @return {!THREE.Texture}

--- a/src/3d/Tile.js
+++ b/src/3d/Tile.js
@@ -124,12 +124,12 @@ FORGE.Tile = function(parent, renderer, x, y, level, face, creator)
     this._opacity = 0;
 
     /**
-     * Texture load pending flag
-     * @name FORGE.Tile#_texturePending
+     * Texture set flag
+     * @name FORGE.Tile#_textureIsSet
      * @type {boolean}
      * @private
      */
-    this._texturePending = false;
+    this._textureIsSet = false;
 
     /**
      * Event dispatcher for destroy.
@@ -291,7 +291,7 @@ FORGE.Tile.prototype._onBeforeRender = function()
     // Add to renderer render list
     this._renderer.addToRenderList(this);
 
-    if (this._texturePending === true)
+    if (this._textureIsSet === true)
     {
         this._setOpacity(1);
     }
@@ -334,7 +334,7 @@ FORGE.Tile.prototype._onAfterRender = function()
 FORGE.Tile.prototype._queryTexture = function()
 {
     // Update texture mapping
-    if (this.material !== null && this.material.map === null && this._texturePending === false)
+    if (this.material !== null && this.material.map === null && this._textureIsSet === false)
     {
         // Check if predelay since creation has been respected (except for preview)
         if ((this._level !== FORGE.Tile.PREVIEW || this._level !== this._renderer.level) &&
@@ -357,7 +357,7 @@ FORGE.Tile.prototype._queryTexture = function()
 
                 if (texture !== null && texture instanceof THREE.Texture)
                 {
-                    this._texturePending = true;
+                    this._textureIsSet = true;
 
                     texture.generateMipmaps = false;
                     texture.minFilter = THREE.LinearFilter;
@@ -1012,15 +1012,15 @@ Object.defineProperty(FORGE.Tile.prototype, "neighbours",
 });
 
 /**
- * Is the texture still pending
- * @name FORGE.Tile#texturePending
+ * Is the texture set
+ * @name FORGE.Tile#textureIsSet
  * @type {boolean}
  */
-Object.defineProperty(FORGE.Tile.prototype, "texturePending",
+Object.defineProperty(FORGE.Tile.prototype, "textureIsSet",
 {
     /** @this {FORGE.Tile} */
     get: function()
     {
-        return this._texturePending;
+        return this._textureIsSet;
     }
 });

--- a/src/3d/Tile.js
+++ b/src/3d/Tile.js
@@ -214,6 +214,11 @@ FORGE.Tile.FACE_NEXT = {
 FORGE.Tile.createName = function(face, level, x, y)
 {
     face = typeof face === "number" ? FORGE.Tile.FACES[face] : face.toLowerCase();
+    if (level === FORGE.Tile.PREVIEW) {
+        return face.substring(0, 1).toUpperCase() + "-preview";
+
+    }
+
     return face.substring(0, 1).toUpperCase() + "-" + level + "-" + y + "-" + x;
 };
 
@@ -250,7 +255,7 @@ FORGE.Tile.prototype._boot = function()
         this._checkParent();
     }
 
-    this.renderOrder = this._level === FORGE.Tile.PREVIEW ? 0 : this._level + 1;
+    this.renderOrder = this._level === FORGE.Tile.PREVIEW ? 0 : 2 * (this._level + 1);
     this.onBeforeRender = this._onBeforeRender.bind(this);
     this.onAfterRender = this._onAfterRender.bind(this);
 
@@ -387,7 +392,6 @@ FORGE.Tile.prototype._addDebugLayer = function()
     var canvas = document.createElement("canvas");
     canvas.width = canvas.height = 512;
     var ctx = canvas.getContext("2d");
-    ctx.fillStyle = "#FF0000";
 
     var x = canvas.width / 2;
     var y = canvas.height / 2 - 25;
@@ -412,7 +416,12 @@ FORGE.Tile.prototype._addDebugLayer = function()
 
     ctx.textAlign = "left";
     ctx.font = "10px Courier";
-    ctx.fillText("Level " + this._level, 10, canvas.height - 10);
+    if (this._level === FORGE.Tile.PREVIEW) {
+        ctx.fillText("Preview", 10, canvas.height - 10);
+    }
+    else {
+        ctx.fillText("Level " + this._level, 10, canvas.height - 10);
+    }
 
     ctx.textAlign = "right";
     ctx.fillText(this._renderer.pixelsAtCurrentLevelHumanReadable, canvas.width - 10, canvas.height - 10);
@@ -429,6 +438,8 @@ FORGE.Tile.prototype._addDebugLayer = function()
     var mesh = new THREE.Mesh(this.geometry.clone(), material);
     mesh.name = this.name + "-debug-canvas";
     this.add(mesh);
+
+    mesh.renderOrder = this.renderOrder + 1;
 };
 
 /**

--- a/src/3d/Tile.js
+++ b/src/3d/Tile.js
@@ -214,9 +214,9 @@ FORGE.Tile.FACE_NEXT = {
 FORGE.Tile.createName = function(face, level, x, y)
 {
     face = typeof face === "number" ? FORGE.Tile.FACES[face] : face.toLowerCase();
-    if (level === FORGE.Tile.PREVIEW) {
+    if (level === FORGE.Tile.PREVIEW)
+    {
         return face.substring(0, 1).toUpperCase() + "-preview";
-
     }
 
     return face.substring(0, 1).toUpperCase() + "-" + level + "-" + y + "-" + x;
@@ -319,7 +319,8 @@ FORGE.Tile.prototype._onAfterRender = function()
     // Update last display timestamp
     this.refreshDisplayTS();
 
-    if (this._level !== FORGE.Tile.PREVIEW) {
+    if (this._level !== FORGE.Tile.PREVIEW)
+    {
         // Check if tile should be divided
         if (this._renderer.level > this._level)
         {
@@ -328,10 +329,12 @@ FORGE.Tile.prototype._onAfterRender = function()
             // Restoration process for required tiles previously removed from the scene
             // Check if children are intersecting the frustum and add them back to the
             // scene (with refreshed display timer)
-            for (var i=0, ii=this._children.length; i<ii; i++) {
+            for (var i=0, ii=this._children.length; i<ii; i++)
+            {
                 var child = this._children[i];
 
-                if (!this._renderer.isObjectInScene(child) && this._renderer.isObjectInFrustum(child)) {
+                if (!this._renderer.isObjectInScene(child) && this._renderer.isObjectInFrustum(child))
+                {
                     this._renderer.scene.add(child);
                     child.refreshDisplayTS();
                 }
@@ -430,10 +433,12 @@ FORGE.Tile.prototype._addDebugLayer = function()
 
     ctx.textAlign = "left";
     ctx.font = "10px Courier";
-    if (this._level === FORGE.Tile.PREVIEW) {
+    if (this._level === FORGE.Tile.PREVIEW)
+    {
         ctx.fillText("Preview", 10, canvas.height - 10);
     }
-    else {
+    else
+    {
         ctx.fillText("Level " + this._level, 10, canvas.height - 10);
     }
 

--- a/src/camera/Camera.js
+++ b/src/camera/Camera.js
@@ -1200,7 +1200,7 @@ FORGE.Camera.prototype.lookAt = function(yaw, pitch, roll, fov, durationMS, canc
 {
     if (typeof durationMS !== "number" || durationMS === 0)
     {
-        var changed =  this._setAll(yaw, pitch, roll, fov, FORGE.Math.DEGREES);
+        var changed = this._setAll(yaw, pitch, roll, fov, FORGE.Math.DEGREES);
 
         if (changed === true)
         {

--- a/src/render/background/BackgroundPyramidRenderer.js
+++ b/src/render/background/BackgroundPyramidRenderer.js
@@ -528,16 +528,6 @@ FORGE.BackgroundPyramidRenderer.prototype.tileSize = function(level)
 };
 
 /**
- * Remove tile from the scene
- * @method FORGE.BackgroundPyramidRenderer#removeFromScene
- * @param {FORGE.Tile} tile
- */
-FORGE.BackgroundPyramidRenderer.prototype.removeFromScene = function(tile)
-{
-    this._scene.remove(tile);
-};
-
-/**
  * Select current level for the pyramid
  * @method FORGE.BackgroundPyramidRenderer#selectLevel
  * @param {number} level pyramid level

--- a/src/render/background/BackgroundPyramidRenderer.js
+++ b/src/render/background/BackgroundPyramidRenderer.js
@@ -388,7 +388,7 @@ FORGE.BackgroundPyramidRenderer.prototype._clearTiles = function()
         // Tile has been displayed a too long time ago
         var timeSinceDisplay = now - tile.displayTS;
         var tileNotDisplayedRecentlyEnough = tile.displayTS !== null
-            && timeSinceDisplay > FORGE.BackgroundPyramidRenderer.MAX_ALLOWED_TIME_SINCE_DISPLAY_MS
+            && timeSinceDisplay > FORGE.BackgroundPyramidRenderer.MAX_ALLOWED_TIME_SINCE_DISPLAY_MS;
 
         // Tile is out of delay and could be cleared
         // This flag will force clearing tiles with lower levels not displayed for a while
@@ -400,13 +400,7 @@ FORGE.BackgroundPyramidRenderer.prototype._clearTiles = function()
         // OR
         // Clear tiles from lower levels (except preview or zero) AND out of delay
         // AND with a texture set AND out of the neighbour list
-        if (tileLevelHigher
-            || (    tileLevelClearable
-                &&  tileOutOfDelay
-                &&  tileHasATexture
-                && !isANeighbourTile
-                )
-            )
+        if (tileLevelHigher || (tileLevelClearable && tileOutOfDelay && tileHasATexture && !isANeighbourTile))
         {
             clearList.push(tile);
         }

--- a/src/render/background/BackgroundRenderer.js
+++ b/src/render/background/BackgroundRenderer.js
@@ -364,7 +364,7 @@ Object.defineProperty(FORGE.BackgroundRenderer.prototype, "scene",
  */
 Object.defineProperty(FORGE.BackgroundRenderer.prototype, "frustum",
 {
-    /** @this {FORGE.Frustum} */
+    /** @this {FORGE.BackgroundRenderer} */
     get: function()
     {
         return this._frustum;


### PR DESCRIPTION
Fix some deficient use cases with multiresolution rendering.
Look somewhere in some high level and display a distant part of the scene at the same level immediately. This was not refreshing without this fix.

We reinject in the scene children of a tile that are in the viewing frustum but out of the scene. 

Additions:
Rewrite clear policy code to improve semantics and clarity
Fix display of tile debugging canvas
Add a frustum property to the background renderer