### PR TITLE
Force the display of visible DOM hotspots into a new scene

### DIFF
--- a/src/hotspots/Hotspot3D.js
+++ b/src/hotspots/Hotspot3D.js
@@ -436,6 +436,24 @@ FORGE.Hotspot3D.prototype.dump = function()
 };
 
 /**
+ * Show the hotspot.
+ * @method FORGE.Hotspot3D#show
+ */
+FORGE.Hotspot3D.prototype.show = function()
+{
+    this.visible = true;
+};
+
+/**
+ * Hide the hotspot.
+ * @method FORGE.Hotspot3D#hide
+ */
+FORGE.Hotspot3D.prototype.hide = function()
+{
+    this.visible = false;
+};
+
+/**
  * Destroy routine
  * @method FORGE.Hotspot3D#destroy
  */

--- a/src/hotspots/HotspotDOM.js
+++ b/src/hotspots/HotspotDOM.js
@@ -388,31 +388,23 @@ FORGE.HotspotDOM.prototype._viewChangeHandler = function()
         this._prevented = true;
         this._preventedConfig.visible = this._visible;
 
-        this.hide();
+        this._hide();
     }
     else
     {
         if (this._prevented === true)
         {
             this._prevented = false;
-
-            if(this._preventedConfig.visible === true)
-            {
-                this.show();
-            }
-            else
-            {
-                this.hide();
-            }
+            this.visible = this._preventedConfig.visible;
         }
     }
 };
 
 /**
  * Show the hotspot by appending it to the DOM container.
- * @method FORGE.HotspotDOM#show
+ * @method FORGE.HotspotDOM#_show
  */
-FORGE.HotspotDOM.prototype.show = function()
+FORGE.HotspotDOM.prototype._show = function()
 {
     this._visible = true;
 
@@ -426,9 +418,9 @@ FORGE.HotspotDOM.prototype.show = function()
 
 /**
  * Hide the hotspot by removing it to the DOM container.
- * @method FORGE.HotspotDOM#hide
+ * @method FORGE.HotspotDOM#_hide
  */
-FORGE.HotspotDOM.prototype.hide = function()
+FORGE.HotspotDOM.prototype._hide = function()
 {
     this._visible = false;
 
@@ -438,6 +430,35 @@ FORGE.HotspotDOM.prototype.hide = function()
     {
         this._viewer.domHotspotContainer.dom.removeChild(this._dom, false);
     }
+};
+
+/**
+ * Show the hotspot.
+ * @method FORGE.HotspotDOM#show
+ */
+FORGE.HotspotDOM.prototype.show = function()
+{
+    if (this._prevented === true)
+    {
+        this._preventedConfig.visible = true;
+        return;
+    }
+
+    this._show();
+};
+
+/**
+ * Hide the hotspot.
+ * @method FORGE.HotspotDOM#hide
+ */
+FORGE.HotspotDOM.prototype.hide = function()
+{
+    if (this._prevented === true)
+    {
+        this._preventedConfig.visible = false;
+    }
+
+    this._hide();
 };
 
 /**

--- a/src/hotspots/HotspotDOM.js
+++ b/src/hotspots/HotspotDOM.js
@@ -392,6 +392,11 @@ FORGE.HotspotDOM.prototype._viewChangeHandler = function()
  */
 FORGE.HotspotDOM.prototype.show = function()
 {
+    //force the display if a "display:none" property was set into css
+    if (this._visible == true)
+    {
+        this._viewChangeHandler();
+    }
     this._viewer.domHotspotContainer.dom.appendChild(this._dom);
 };
 


### PR DESCRIPTION
Solve issues if the "display:none" property was set on a DOM hotspot and solve the issue if an other scene is called and uses the same view (which is not refreshed).